### PR TITLE
Refactor: extract duplicated load_model error handling into helper cl…

### DIFF
--- a/src-tauri/src/managers/transcription.rs
+++ b/src-tauri/src/managers/transcription.rs
@@ -248,43 +248,35 @@ impl TranscriptionManager {
 
         let model_path = self.model_manager.get_model_path(model_id)?;
 
+        // Helper to emit a loading_failed event and return an error.
+        let emit_load_failure = |engine_label: &str, err: &dyn std::fmt::Display| -> anyhow::Error {
+            let error_msg = format!("Failed to load {} model {}: {}", engine_label, model_id, err);
+            let _ = self.app_handle.emit(
+                "model-state-changed",
+                ModelStateEvent {
+                    event_type: "loading_failed".to_string(),
+                    model_id: Some(model_id.to_string()),
+                    model_name: Some(model_info.name.clone()),
+                    error: Some(error_msg.clone()),
+                },
+            );
+            anyhow::anyhow!(error_msg)
+        };
+
         // Create appropriate engine based on model type
         let loaded_engine = match model_info.engine_type {
             EngineType::Whisper => {
                 let mut engine = WhisperEngine::new();
-                engine.load_model(&model_path).map_err(|e| {
-                    let error_msg = format!("Failed to load whisper model {}: {}", model_id, e);
-                    let _ = self.app_handle.emit(
-                        "model-state-changed",
-                        ModelStateEvent {
-                            event_type: "loading_failed".to_string(),
-                            model_id: Some(model_id.to_string()),
-                            model_name: Some(model_info.name.clone()),
-                            error: Some(error_msg.clone()),
-                        },
-                    );
-                    anyhow::anyhow!(error_msg)
-                })?;
+                engine
+                    .load_model(&model_path)
+                    .map_err(|e| emit_load_failure("whisper", &e))?;
                 LoadedEngine::Whisper(engine)
             }
             EngineType::Parakeet => {
                 let mut engine = ParakeetEngine::new();
                 engine
                     .load_model_with_params(&model_path, ParakeetModelParams::int8())
-                    .map_err(|e| {
-                        let error_msg =
-                            format!("Failed to load parakeet model {}: {}", model_id, e);
-                        let _ = self.app_handle.emit(
-                            "model-state-changed",
-                            ModelStateEvent {
-                                event_type: "loading_failed".to_string(),
-                                model_id: Some(model_id.to_string()),
-                                model_name: Some(model_info.name.clone()),
-                                error: Some(error_msg.clone()),
-                            },
-                        );
-                        anyhow::anyhow!(error_msg)
-                    })?;
+                    .map_err(|e| emit_load_failure("parakeet", &e))?;
                 LoadedEngine::Parakeet(engine)
             }
             EngineType::Moonshine => {
@@ -294,62 +286,21 @@ impl TranscriptionManager {
                         &model_path,
                         MoonshineModelParams::variant(ModelVariant::Base),
                     )
-                    .map_err(|e| {
-                        let error_msg =
-                            format!("Failed to load moonshine model {}: {}", model_id, e);
-                        let _ = self.app_handle.emit(
-                            "model-state-changed",
-                            ModelStateEvent {
-                                event_type: "loading_failed".to_string(),
-                                model_id: Some(model_id.to_string()),
-                                model_name: Some(model_info.name.clone()),
-                                error: Some(error_msg.clone()),
-                            },
-                        );
-                        anyhow::anyhow!(error_msg)
-                    })?;
+                    .map_err(|e| emit_load_failure("moonshine", &e))?;
                 LoadedEngine::Moonshine(engine)
             }
             EngineType::MoonshineStreaming => {
                 let mut engine = MoonshineStreamingEngine::new();
                 engine
                     .load_model_with_params(&model_path, StreamingModelParams::default())
-                    .map_err(|e| {
-                        let error_msg = format!(
-                            "Failed to load moonshine streaming model {}: {}",
-                            model_id, e
-                        );
-                        let _ = self.app_handle.emit(
-                            "model-state-changed",
-                            ModelStateEvent {
-                                event_type: "loading_failed".to_string(),
-                                model_id: Some(model_id.to_string()),
-                                model_name: Some(model_info.name.clone()),
-                                error: Some(error_msg.clone()),
-                            },
-                        );
-                        anyhow::anyhow!(error_msg)
-                    })?;
+                    .map_err(|e| emit_load_failure("moonshine streaming", &e))?;
                 LoadedEngine::MoonshineStreaming(engine)
             }
             EngineType::SenseVoice => {
                 let mut engine = SenseVoiceEngine::new();
                 engine
                     .load_model_with_params(&model_path, SenseVoiceModelParams::int8())
-                    .map_err(|e| {
-                        let error_msg =
-                            format!("Failed to load SenseVoice model {}: {}", model_id, e);
-                        let _ = self.app_handle.emit(
-                            "model-state-changed",
-                            ModelStateEvent {
-                                event_type: "loading_failed".to_string(),
-                                model_id: Some(model_id.to_string()),
-                                model_name: Some(model_info.name.clone()),
-                                error: Some(error_msg.clone()),
-                            },
-                        );
-                        anyhow::anyhow!(error_msg)
-                    })?;
+                    .map_err(|e| emit_load_failure("SenseVoice", &e))?;
                 LoadedEngine::SenseVoice(engine)
             }
         };


### PR DESCRIPTION
…osure

The load_model method repeated the same error-emission + event pattern 5 times (once per engine type). Extract an emit_load_failure closure to eliminate the duplication, reducing ~70 lines while making it easier to add new engine types in the future.

https://claude.ai/code/session_01BDaTH2pLvpsWojboC2EFKk

## Before Submitting This PR

**Please confirm you have done the following:**

- [ ] I have searched [existing issues](https://github.com/elwin/handless/issues) and [pull requests](https://github.com/elwin/handless/pulls) (including closed ones) to ensure this isn't a duplicate
- [ ] I have read [CONTRIBUTING.md](https://github.com/elwin/handless/blob/main/CONTRIBUTING.md)

**If this is a feature or change that was previously closed/rejected:**

- [ ] I have explained in the description below why this should be reconsidered
- [ ] I have gathered community feedback (link to discussion below)

## Human Written Description

<!-- Describe your changes clearly and concisely

Please write 2-3 sentences in your own words explaining:
- What problem you noticed or idea you had
- Why you think this change matters

This section should be YOUR thinking, not AI-generated text. Even if AI helped write the code, we want to hear from you directly. Your perspective as a human is what makes contributions meaningful. Your PR may be rejected if you do not
include a human-written description.
-->

## Related Issues/Discussions

<!-- Link to related issues, discussions, or previous PRs -->
<!-- If reopening something previously closed, explain why this should be reconsidered -->

Fixes #
Discussion:

## Community Feedback

<!--
PRs with community support are much more likely to be merged.

For features: Link to a discussion where community members have expressed interest.
For bug fixes: Link to the issue where others have confirmed the bug.

If you haven't gathered feedback yet, consider starting a discussion first:
https://github.com/elwin/handless/discussions

It is not explicitly required to gather feedback, but it certainly helps your PR get merged.
-->

## Testing

<!-- Describe how you tested your changes and if you need help getting additional testing -->

## Screenshots/Videos (if applicable)

<!-- Add screenshots or videos demonstrating the change -->

## AI Assistance

<!-- AI-assisted PRs are welcome! Just let us know so we can review appropriately. -->

- [ ] No AI was used in this PR
- [ ] AI was used (please describe below)

**If AI was used:**

- Tools used:
- How extensively:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of `load_model` error handling that centralizes event emission/message formatting; behavior should be unchanged aside from potential minor error-string differences.
> 
> **Overview**
> Refactors `TranscriptionManager::load_model` to extract repeated “load failed” logic into a single `emit_load_failure` closure.
> 
> All engine loaders (`Whisper`, `Parakeet`, `Moonshine`, `MoonshineStreaming`, `SenseVoice`) now use the shared helper to emit the `model-state-changed` `loading_failed` event and return a consistent `anyhow` error, reducing duplicated code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5929f7c07ac1f2bf720bbb76b5eb45e6b292763c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->