### PR TITLE
chore(deps): update safe patch/minor dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@tauri-apps/plugin-process": "~2.3.1",
     "@tauri-apps/plugin-sql": "~2.3.1",
     "@tauri-apps/plugin-store": "~2.4.1",
-    "@tauri-apps/plugin-updater": "~2.9.0",
+    "@tauri-apps/plugin-updater": "~2.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "geist": "^1.7.0",
@@ -87,14 +87,13 @@
     "@types/node": "^24.9.1",
     "@types/react": "^18.3.26",
     "@types/react-dom": "^18.3.7",
-    "@types/react-select": "^5.0.1",
     "@typescript-eslint/eslint-plugin": "^8.49.0",
     "@typescript-eslint/parser": "^8.49.0",
     "@vitejs/plugin-react": "^4.7.0",
     "eslint": "^9.39.1",
     "eslint-plugin-i18next": "^6.1.3",
     "prettier": "^3.6.2",
-    "typescript": "~5.6.3",
+    "typescript": "~5.9.0",
     "vite": "^6.4.1"
   }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,15 +36,15 @@ tauri = { version = "2.9.1", features = [
   "tray-icon",
   'image-png',
 ] }
-tauri-plugin-log = "2.7.1"
-tauri-plugin-opener = "2.5.2"
-tauri-plugin-store = "2.4.1"
+tauri-plugin-log = "2.8.0"
+tauri-plugin-opener = "2.5.3"
+tauri-plugin-store = "2.4.2"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-clipboard-manager = "2.3.2"
 tauri-plugin-macos-permissions = "2.3.0"
 tauri-plugin-process = "2.3.1"
-rusqlite_migration = "2.3"
-tauri-plugin-fs = "2.4.4"
+rusqlite_migration = "2.4.1"
+tauri-plugin-fs = "2.4.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rdev = { git = "https://github.com/rustdesk-org/rdev" }
@@ -52,9 +52,9 @@ cpal = "0.16.0"
 anyhow = "1.0.95"
 rubato = "0.16.2"
 hound = "3.5.1"
-log = "0.4.25"
+log = "0.4.29"
 env_filter = "0.1.0"
-tokio = "1.43.0"
+tokio = "1.50.0"
 vad-rs = { git = "https://github.com/cjpais/vad-rs", default-features = false }
 enigo = "0.6.1"
 rodio = { git = "https://github.com/cjpais/rodio.git" }
@@ -71,12 +71,12 @@ chrono = "0.4"
 rusqlite = { version = "0.37", features = ["bundled"] }
 tar = "0.4.44"
 flate2 = "1.0"
-transcribe-rs = { version = "0.2.5", features = ["whisper", "parakeet", "moonshine", "sense_voice"] }
-handy-keys = "0.2.1"
+transcribe-rs = { version = "0.2.9", features = ["whisper", "parakeet", "moonshine", "sense_voice"] }
+handy-keys = "0.2.2"
 ferrous-opencc = "0.2.3"
 clap = { version = "4", features = ["derive"] }
-specta = "=2.0.0-rc.22"
-specta-typescript = "0.0.9"
+specta = "=2.0.0-rc.23"
+specta-typescript = "0.0.10"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 tauri-plugin-dialog = "2"
 window-vibrancy = "0.6"
@@ -87,8 +87,8 @@ signal-hook = "0.3"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-global-shortcut = "2.3.1"
-tauri-plugin-single-instance = "2.3.2"
-tauri-plugin-updater = "2.9.0"
+tauri-plugin-single-instance = "2.4.0"
+tauri-plugin-updater = "2.10.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.3", features = [


### PR DESCRIPTION
Applies safe patch/minor dependency updates from the Renovate Dependency Dashboard (issue #5).

Updates 13 Rust crates and 3 npm packages with no breaking changes.

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only update, but it touches core runtime/build tooling (e.g., `tokio`, Tauri plugins including `plugin-updater`, and `typescript`), which can introduce build or runtime regressions despite being patch/minor bumps.
> 
> **Overview**
> Updates the app’s dependency set across both frontend and Tauri backend.
> 
> On the frontend, bumps `@tauri-apps/plugin-updater` and upgrades the `typescript` toolchain (and drops `@types/react-select`). On the Rust side, bumps multiple crates including Tauri plugins (notably `tauri-plugin-updater`, `tauri-plugin-single-instance`, `tauri-plugin-log/store/opener/fs`), plus core libs like `tokio`, `log`, `rusqlite_migration`, `transcribe-rs`, and `specta-typescript`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14cd898fa5865c58f9d879b3ef350e8669ed69b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->