### PR TITLE
ci(release): temporarily disable Windows and Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,21 +52,21 @@ jobs:
           - platform: "macos-latest" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
             target: "x86_64-apple-darwin"
-          - platform: "ubuntu-22.04" # Build .deb on 22.04
-            args: "--bundles deb"
-            target: "x86_64-unknown-linux-gnu"
-          - platform: "ubuntu-24.04" # Build AppImage and RPM on 24.04
-            args: "--bundles appimage,rpm"
-            target: "x86_64-unknown-linux-gnu"
-          - platform: "ubuntu-24.04-arm" # Build for ARM64 Linux
-            args: "--bundles appimage,deb,rpm"
-            target: "aarch64-unknown-linux-gnu"
-          - platform: "windows-latest"
-            args: ""
-            target: "x86_64-pc-windows-msvc"
-          - platform: "windows-11-arm" # for ARM64 Windows runner
-            args: "--target aarch64-pc-windows-msvc"
-            target: "aarch64-pc-windows-msvc"
+          # - platform: "ubuntu-22.04" # Build .deb on 22.04
+          #   args: "--bundles deb"
+          #   target: "x86_64-unknown-linux-gnu"
+          # - platform: "ubuntu-24.04" # Build AppImage and RPM on 24.04
+          #   args: "--bundles appimage,rpm"
+          #   target: "x86_64-unknown-linux-gnu"
+          # - platform: "ubuntu-24.04-arm" # Build for ARM64 Linux
+          #   args: "--bundles appimage,deb,rpm"
+          #   target: "aarch64-unknown-linux-gnu"
+          # - platform: "windows-latest"
+          #   args: ""
+          #   target: "x86_64-pc-windows-msvc"
+          # - platform: "windows-11-arm" # for ARM64 Windows runner
+          #   args: "--target aarch64-pc-windows-msvc"
+          #   target: "aarch64-pc-windows-msvc"
 
     uses: ./.github/workflows/build.yml
     with:


### PR DESCRIPTION
## Summary
- Comments out all Windows and Linux matrix entries in the release workflow
- Only macOS (arm64 and x86_64) will be built and published until re-enabled

## Test plan
- [ ] Trigger a release to confirm only macOS jobs run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release automation will no longer build/publish Linux and Windows artifacts, which could lead to incomplete releases if re-enabled is forgotten or if consumers expect those binaries.
> 
> **Overview**
> Updates the `release.yml` GitHub Actions workflow to **only run macOS builds** by commenting out all Linux and Windows entries in the `publish-tauri` matrix.
> 
> As a result, releases created via this workflow will publish macOS (`aarch64-apple-darwin` and `x86_64-apple-darwin`) artifacts only until the matrix entries are re-enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dc3027429705c884381a4632123fad27ab77a5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->