### PR TITLE
fix(settings): keep prompt selection in sync between bindings and post-processing page

### DIFF
--- a/src-tauri/src/post_process/commands.rs
+++ b/src-tauri/src/post_process/commands.rs
@@ -222,6 +222,14 @@ pub fn delete_post_process_prompt(app: AppHandle, id: String) -> Result<(), Stri
             settings.post_process_prompts.first().map(|p| p.id.clone());
     }
 
+    // Update any bindings that referenced the deleted prompt
+    for binding in settings.bindings.values_mut() {
+        if binding.post_process_prompt_id.as_ref() == Some(&id) {
+            binding.post_process_prompt_id =
+                settings.post_process_selected_prompt_id.clone();
+        }
+    }
+
     settings::write_settings(&app, settings);
     Ok(())
 }
@@ -236,7 +244,13 @@ pub fn set_post_process_selected_prompt(app: AppHandle, id: String) -> Result<()
         return Err(format!("Prompt with id '{}' not found", id));
     }
 
-    settings.post_process_selected_prompt_id = Some(id);
+    settings.post_process_selected_prompt_id = Some(id.clone());
+
+    // Keep the default transcribe binding's prompt in sync
+    if let Some(binding) = settings.bindings.get_mut("transcribe") {
+        binding.post_process_prompt_id = Some(id);
+    }
+
     settings::write_settings(&app, settings);
     Ok(())
 }

--- a/src-tauri/src/shortcut/mod.rs
+++ b/src-tauri/src/shortcut/mod.rs
@@ -315,7 +315,13 @@ pub fn update_binding_prompt(
     let mut settings = settings::get_settings(&app);
 
     if let Some(binding) = settings.bindings.get_mut(&id) {
-        binding.post_process_prompt_id = prompt_id;
+        binding.post_process_prompt_id = prompt_id.clone();
+
+        // Keep the post-processing page selection in sync with the default shortcut
+        if id == "transcribe" {
+            settings.post_process_selected_prompt_id = prompt_id;
+        }
+
         settings::write_settings(&app, settings);
         Ok(())
     } else {


### PR DESCRIPTION
## Summary
- Bidirectionally sync `post_process_selected_prompt_id` with the default transcribe binding's `post_process_prompt_id`
- When a prompt is deleted, update all bindings that referenced it to fall back to the current selection
- Prevents stale prompt references in bindings after deletion

## Test plan
- [ ] Change prompt on post-processing page → verify transcribe binding's prompt updates
- [ ] Change prompt on transcribe binding → verify post-processing page selection updates
- [ ] Delete a prompt that is assigned to a binding → verify binding falls back to the selected prompt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small settings-management changes that only adjust how prompt IDs are propagated between the default `transcribe` binding and the post-processing UI, plus cleanup of stale references on prompt deletion.
> 
> **Overview**
> Ensures the post-processing page’s selected prompt and the default `transcribe` shortcut’s `post_process_prompt_id` stay **bidirectionally synchronized** (selection changes update the binding, and binding changes update the page selection).
> 
> When a post-process prompt is deleted, any shortcut bindings still referencing that prompt are now automatically updated to fall back to the current selected prompt, preventing stale prompt IDs in settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d749d35442aef0194af6254d726849233609e7bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->