### PR TITLE
fix(ux): change history retention default to Never and move controls to History page

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -457,7 +457,7 @@ fn default_history_limit() -> usize {
 }
 
 fn default_recording_retention_period() -> RecordingRetentionPeriod {
-    RecordingRetentionPeriod::PreserveLimit
+    RecordingRetentionPeriod::Never
 }
 
 fn default_audio_feedback_volume() -> f32 {

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -11,7 +11,7 @@ import { PasteMethodSetting } from "../PasteMethod";
 import { TypingToolSetting } from "../TypingTool";
 import { ClipboardHandlingSetting } from "../ClipboardHandling";
 import { AutoSubmit } from "../AutoSubmit";
-import { RecordingRetentionPeriodSelector } from "../RecordingRetentionPeriod";
+
 import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationSelector";
 import { ExportImportSettings } from "./ExportImportSettings";
 import { ConfigFileSettings } from "./ConfigFileSettings";
@@ -39,13 +39,6 @@ export const AdvancedSettings: React.FC = () => {
         <TypingToolSetting descriptionMode="tooltip" grouped={true} />
         <ClipboardHandlingSetting descriptionMode="tooltip" grouped={true} />
         <AutoSubmit descriptionMode="tooltip" grouped={true} />
-      </SettingsGroup>
-
-      <SettingsGroup title={t("settings.advanced.groups.history")}>
-        <RecordingRetentionPeriodSelector
-          descriptionMode="tooltip"
-          grouped={true}
-        />
       </SettingsGroup>
 
       <SettingsGroup title={t("settings.advanced.groups.data")}>

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -18,6 +18,7 @@ import { commands, type HistoryEntry } from "@/bindings";
 import { formatRelativeTime, formatDateTime } from "@/utils/dateFormat";
 import { useOsType } from "@/hooks/useOsType";
 import { SimpleTooltip } from "../../ui/Tooltip";
+import { RecordingRetentionPeriodSelector } from "../RecordingRetentionPeriod";
 
 interface OpenRecordingsButtonProps {
   onClick: () => void;
@@ -135,9 +136,17 @@ export const HistorySettings: React.FC = () => {
     }
   };
 
+  const retentionSection = (
+    <RecordingRetentionPeriodSelector
+      descriptionMode="inline"
+      grouped={false}
+    />
+  );
+
   if (loading) {
     return (
       <div className="max-w-3xl w-full mx-auto space-y-4">
+        {retentionSection}
         <div className="space-y-1.5">
           <div className="px-3 flex items-center justify-between">
             <div>
@@ -166,6 +175,7 @@ export const HistorySettings: React.FC = () => {
   if (historyEntries.length === 0) {
     return (
       <div className="max-w-3xl w-full mx-auto space-y-4">
+        {retentionSection}
         <div className="space-y-1.5">
           <div className="px-3 flex items-center justify-between">
             <div>
@@ -195,6 +205,7 @@ export const HistorySettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      {retentionSection}
       <div className="space-y-1.5">
         <div className="px-3 flex items-center justify-between">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Closes #42

- Change default recording retention period from `PreserveLimit` to `Never`, so fresh installs preserve all history by default
- Move history cleanup controls from Advanced settings page to History settings page, making them easier to discover
- Users can still opt-in to cleanup policy (Never / Keep latest N / time-based) from History page

## Test plan

- [ ] Fresh install: verify default retention is "Never" (no auto-deletion)
- [ ] History page: verify cleanup controls are visible and functional
- [ ] Advanced page: verify history cleanup group is removed
- [ ] Changing retention policy works correctly from History page

🤖 Generated with [Claude Code](https://claude.com/claude-code)