### PR TITLE
feat(stt): switch Soniox default to realtime model

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -565,7 +565,7 @@ fn default_stt_providers() -> Vec<SttProvider> {
             label: "Soniox".to_string(),
             provider_type: SttProviderType::Cloud,
             base_url: "https://api.soniox.com/v1".to_string(),
-            default_model: "stt-async-v4".to_string(),
+            default_model: "stt-rt-preview".to_string(),
         },
     ]
 }
@@ -644,6 +644,15 @@ fn ensure_stt_defaults(settings: &mut AppSettings) -> bool {
             }
         }
     }
+
+    // Default realtime to true for providers that support it
+    for info in crate::stt_provider::cloud_provider_registry() {
+        if info.supports_realtime && !settings.stt_realtime_enabled.contains_key(&info.id) {
+            settings.stt_realtime_enabled.insert(info.id, true);
+            changed = true;
+        }
+    }
+
     changed
 }
 

--- a/src-tauri/src/stt_provider.rs
+++ b/src-tauri/src/stt_provider.rs
@@ -103,7 +103,7 @@ pub fn cloud_provider_registry() -> Vec<SttProviderInfo> {
         SttProviderInfo {
             id: "soniox".to_string(),
             name: "Soniox".to_string(),
-            description: "Soniox cloud speech-to-text. High accuracy with async transcription.".to_string(),
+            description: "Soniox cloud speech-to-text. High accuracy with realtime transcription.".to_string(),
             supported_languages: vec![
                 "af", "sq", "ar", "az", "eu", "be", "bn", "bs", "bg", "ca",
                 "zh-Hans", "zh-Hant", "hr", "cs", "da", "nl", "en", "et", "fi", "fr",
@@ -117,7 +117,7 @@ pub fn cloud_provider_registry() -> Vec<SttProviderInfo> {
             is_recommended: false,
             backend: ProviderBackend::Cloud {
                 base_url: "https://api.soniox.com/v1".to_string(),
-                default_model: "stt-async-v4".to_string(),
+                default_model: "stt-rt-preview".to_string(),
                 console_url: Some("https://console.soniox.com".to_string()),
             },
             available_options: vec![


### PR DESCRIPTION
## Summary
- Switch Soniox provider from async (`stt-async-v4`) to realtime (`stt-rt-preview`) transcription model
- Auto-enable realtime mode for cloud providers that support it when no user preference exists
- Update Soniox description to reflect realtime capability

## Notes
- Existing users who already have Soniox configured will keep `stt-async-v4` — the new default only applies to fresh setups or new providers
- The realtime default is only set when `stt_realtime_enabled` has no entry for the provider, so explicit user choices are preserved

## Test plan
- [ ] Fresh install: verify Soniox defaults to `stt-rt-preview` and realtime is enabled
- [ ] Existing install with Soniox configured: verify model stays on `stt-async-v4` unless manually changed
- [ ] Toggle realtime off for Soniox, restart — verify preference is preserved
- [ ] Test Soniox transcription works with the new realtime model