### PR TITLE
chore: remove Renovate dependency bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "rebaseWhen": "behind-base-branch",
-  "ignoreDeps": ["windows"]
-}


### PR DESCRIPTION
## Summary

- Remove `renovate.json` config to disable automated dependency update PRs
- Dependency updates will be managed manually going forward

### Context

Renovate caused several issues:
- Version drift between npm and Cargo lockfiles for shared Tauri plugins (resolved in #46)
- Multiple merged-then-reverted updates (cpal 0.17, rubato 1.0, specta rc.23, eslint v10, windows 0.62) due to breaking changes it couldn't detect
- Unnecessary noise from blocked PRs that can't be applied

### Cleanup (after merge)

The following will also be cleaned up:
- 15 stale `renovate/*` remote branches
- Dependency Dashboard issue #5

## Test plan

- [ ] Verify CI passes
- [ ] Confirm Renovate stops creating PRs after merge