### PR TITLE
chore(renovate): require dashboard approval before creating PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "dependencyDashboardApproval": true,
+  "rebaseWhen": "behind-base-branch",
+  "ignoreDeps": ["windows"]
 }


### PR DESCRIPTION
## Summary

- Add `dependencyDashboardApproval: true` — Renovate will only list available updates on the Dependency Dashboard issue, and will **not** create PRs unless manually approved via checkbox
- Restore `rebaseWhen` and `ignoreDeps: ["windows"]` settings that were lost when Renovate recreated its config

## Test plan

- [ ] Verify Renovate stops auto-creating PRs after merge
- [ ] Confirm Dependency Dashboard issue still shows available updates