### PR TITLE
chore: remove Renovate dependency bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
## Summary

- Remove `renovate.json` to fully disable Renovate
- Dependencies will be managed manually going forward

**Important:** After merging, uninstall the Renovate GitHub App from repo settings (`Settings → Integrations → GitHub Apps`) to prevent it from recreating its config.

## Test plan

- [ ] Verify Renovate stops running after merge + app uninstall