### PR TITLE
fix(ci): use --locked to prevent Windows build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,7 +287,7 @@ jobs:
           releaseName: ${{ inputs.release-id && format('v{0}', steps.get-version.outputs.version) || '' }}
           releaseId: ${{ inputs.release-id }}
           assetNamePattern: ${{ steps.patch-release-name.outputs.platform }}
-          args: ${{ inputs.build-args }}
+          args: "${{ inputs.build-args }} -- --locked"
 
       - name: Build with Tauri (unsigned)
         if: ${{ !inputs.sign-binaries }}
@@ -303,7 +303,7 @@ jobs:
           releaseName: ${{ inputs.release-id && format('v{0}', steps.get-version.outputs.version) || '' }}
           releaseId: ${{ inputs.release-id }}
           assetNamePattern: ${{ steps.patch-release-name.outputs.platform }}
-          args: ${{ inputs.build-args }}
+          args: "${{ inputs.build-args }} -- --locked"
 
       - name: Upload artifacts (macOS)
         if: inputs.upload-artifacts && contains(inputs.platform, 'macos')


### PR DESCRIPTION
## Summary
- Windows CI builds were failing with `error[E0308]: mismatched types` in `overlay.rs` due to two versions of the `windows` crate (v0.61.3 and v0.62.2) being resolved in the dependency graph
- Root cause: `cargo` was re-resolving dependencies during `tauri build` on CI, pulling in `windows v0.62.2` (via transitive deps like `iana-time-zone`) alongside the lockfile-pinned `v0.61.3`
- Fix: pass `--locked` to cargo via tauri build args to enforce the committed `Cargo.lock`

## Test plan
- [ ] Trigger Build Test workflow and verify Windows x64 and ARM64 builds pass
- [ ] Verify macOS and Linux builds are unaffected