### PR TITLE
refactor: use tooltip for retention description and remove entries label

### DIFF
--- a/src/components/settings/RecordingRetentionPeriod.tsx
+++ b/src/components/settings/RecordingRetentionPeriod.tsx
@@ -69,9 +69,6 @@ export const RecordingRetentionPeriodSelector: React.FC<RecordingRetentionPeriod
                 onChange={handleLimitChange}
                 disabled={isUpdating("history_limit")}
               />
-              <span className="text-sm text-text whitespace-nowrap">
-                {t("settings.debug.recordingRetention.entries")}
-              </span>
             </>
           )}
         </div>

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -138,7 +138,7 @@ export const HistorySettings: React.FC = () => {
 
   const retentionSection = (
     <RecordingRetentionPeriodSelector
-      descriptionMode="inline"
+      descriptionMode="tooltip"
       grouped={false}
     />
   );


### PR DESCRIPTION
## Summary
- Changed recording retention period description from inline text to tooltip icon, consistent with other settings like API key
- Removed the redundant "entries" label after the number input when "keep latest" is selected

## Test plan
- [ ] Verify retention period setting shows description as tooltip on hover
- [ ] Verify "keep latest" option shows only the number input without "entries" text