### PR TITLE
fix: skip post-processing when provider is not verified

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -256,12 +256,22 @@ impl ShortcutAction for TranscribeAction {
 
         let binding_id = binding_id.to_string();
 
-        // Look up the post-processing prompt for this binding
+        // Look up the post-processing prompt for this binding.
+        // If the provider is not verified, treat as no prompt so we skip post-processing entirely.
         let settings_snapshot = get_settings(app);
-        let post_process_prompt_id = settings_snapshot
-            .bindings
-            .get(&binding_id)
-            .and_then(|b| b.post_process_prompt_id.clone());
+        let provider_id = &settings_snapshot.post_process_provider_id;
+        let provider_ready = provider_id == "apple_intelligence"
+            || settings_snapshot
+                .post_process_verified_providers
+                .contains(provider_id);
+        let post_process_prompt_id = if provider_ready {
+            settings_snapshot
+                .bindings
+                .get(&binding_id)
+                .and_then(|b| b.post_process_prompt_id.clone())
+        } else {
+            None
+        };
 
         tauri::async_runtime::spawn(async move {
             let _guard = FinishGuard(ah.clone());

--- a/src-tauri/src/post_process/process.rs
+++ b/src-tauri/src/post_process/process.rs
@@ -92,6 +92,17 @@ pub async fn post_process_transcription(
         return None;
     }
 
+    // Skip post-processing if the provider is not verified (except Apple Intelligence)
+    if provider.id != "apple_intelligence"
+        && !settings.post_process_verified_providers.contains(&provider.id)
+    {
+        debug!(
+            "Post-processing skipped because provider '{}' is not verified",
+            provider.id
+        );
+        return None;
+    }
+
     let prompt = match settings
         .post_process_prompts
         .iter()


### PR DESCRIPTION
## Summary
- When the post-process API provider is not verified, the binding's `post_process_prompt_id` is now treated as `None` in `actions.rs`, preventing the processing overlay and failed API calls
- Added a defense-in-depth check in `process.rs` that returns early if the provider is not in `post_process_verified_providers` (Apple Intelligence exempt)
- The UI already disables the prompt dropdown when unverified, but a previously saved selection could still trigger a backend call — this fix closes that gap

## Test plan
- [ ] Set up a post-process provider, select a prompt for a shortcut binding, then invalidate the provider (e.g. clear API key) — recording should skip post-processing without errors
- [ ] Verify Apple Intelligence still works without needing to be in `verified_providers`
- [ ] Verify a verified provider with a selected prompt still post-processes correctly