### PR TITLE
fix(theme): use CSS variables for stats chart colors

### DIFF
--- a/src/components/settings/stats/StatsSettings.tsx
+++ b/src/components/settings/stats/StatsSettings.tsx
@@ -82,7 +82,7 @@ const RANGE_PRESETS: StatsDateRange[] = [
   "custom",
 ];
 
-const ACCENT_COLOR = "#ef6f2f";
+const ACCENT_COLOR = "var(--color-accent)";
 
 export const StatsSettings: React.FC = () => {
   const { t, i18n } = useTranslation();
@@ -260,26 +260,26 @@ export const StatsSettings: React.FC = () => {
               <LineChart data={chartData}>
                 <XAxis
                   dataKey="date"
-                  tick={{ fontSize: 10, fill: "rgba(255,255,255,0.55)" }}
+                  tick={{ fontSize: 10, fill: "var(--color-muted)" }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <YAxis
-                  tick={{ fontSize: 10, fill: "rgba(255,255,255,0.55)" }}
+                  tick={{ fontSize: 10, fill: "var(--color-muted)" }}
                   axisLine={false}
                   tickLine={false}
                   width={30}
                 />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "rgba(30, 30, 30, 0.85)",
+                    backgroundColor: "var(--color-glass-bg-solid)",
                     backdropFilter: "blur(12px)",
-                    border: "1px solid rgba(255,255,255,0.1)",
+                    border: "1px solid var(--color-glass-border)",
                     borderRadius: "8px",
                     fontSize: "12px",
-                    color: "rgba(255,255,255,0.9)",
+                    color: "var(--color-text)",
                   }}
-                  labelStyle={{ color: "rgba(255,255,255,0.6)" }}
+                  labelStyle={{ color: "var(--color-muted)" }}
                 />
                 <Line
                   type="monotone"


### PR DESCRIPTION
## Summary
- Replace hard-coded dark-mode colors in the stats chart (tick fill, tooltip background/border/text) with theme-aware CSS custom properties (`--color-muted`, `--color-text`, `--color-glass-bg-solid`, `--color-glass-border`)
- Change `ACCENT_COLOR` from hard-coded `#ef6f2f` to `var(--color-accent)` so it stays in sync with the theme
- Fixes chart being unreadable in light mode (white-on-white ticks, dark tooltip clashing with light background)

## Test plan
- [ ] Open the stats chart in dark mode and verify ticks, tooltip, and accent line render correctly
- [ ] Switch to light mode and verify the chart is fully readable with appropriate colors