### PR TITLE
fix(theme): use design tokens for accessibility permissions button

### DIFF
--- a/src/components/AccessibilityPermissions.tsx
+++ b/src/components/AccessibilityPermissions.tsx
@@ -77,7 +77,7 @@ const AccessibilityPermissions: React.FC = () => {
     verify: {
       text: t("accessibility.openSettings"),
       className:
-        "bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium py-1 px-3 rounded text-sm flex items-center justify-center cursor-pointer",
+        "bg-glass-bg border border-glass-border text-text hover:bg-glass-highlight font-medium py-1 px-3 rounded text-sm flex items-center justify-center cursor-pointer",
     },
     granted: null,
   };


### PR DESCRIPTION
## Summary
- Replace hard-coded `bg-gray-100 hover:bg-gray-200 text-gray-800` on the "verify" button in `AccessibilityPermissions` with design token classes (`bg-glass-bg border border-glass-border text-text hover:bg-glass-highlight`)
- Fixes the button appearing as a bright white element with dark text that clashes in dark mode

## Test plan
- [ ] Verify the accessibility permissions button renders correctly in light mode
- [ ] Verify the button renders correctly in dark mode (no bright white clash)
- [ ] Confirm hover state works in both themes