### PR TITLE
fix(stats): make stats grid responsive on narrow viewports

### DIFF
--- a/src/components/settings/stats/StatsSettings.tsx
+++ b/src/components/settings/stats/StatsSettings.tsx
@@ -221,7 +221,7 @@ export const StatsSettings: React.FC = () => {
     content = (
       <>
         {/* Summary cards */}
-        <div className="px-3 grid grid-cols-4 gap-2">
+        <div className="px-3 grid grid-cols-2 sm:grid-cols-4 gap-2">
           <StatCard
             icon={ChatText}
             label={t("settings.stats.wordsSpoken")}


### PR DESCRIPTION
## Summary
- Change stats grid from fixed `grid-cols-4` to `grid-cols-2 sm:grid-cols-4` so stat cards stack into 2 columns on narrow viewports instead of being compressed or overflowing.

## Test plan
- [ ] Resize the app window to a narrow width and verify stat cards display in 2 columns
- [ ] At wider widths, verify stat cards display in 4 columns as before