### PR TITLE
fix(a11y): render CardTitle as h3 for heading semantics

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -26,10 +26,10 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-  <div
+  <h3
     ref={ref}
     className={cn("font-semibold leading-none tracking-tight", className)}
     {...props}


### PR DESCRIPTION
## Summary
- Change `CardTitle` from `<div>` to `<h3>` so screen readers announce it as a heading (WCAG 1.3.1)
- Update ref and props types from `HTMLDivElement` to `HTMLHeadingElement`

## Test plan
- [ ] Verify cards still render correctly with no visual regression
- [ ] Confirm screen readers (e.g. VoiceOver) announce card titles as headings