### PR TITLE
fix: remove debug console.log from HistorySettings

### DIFF
--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -66,7 +66,6 @@ export const HistorySettings: React.FC = () => {
 
     const setupListener = async () => {
       const unlisten = await listen("history-updated", () => {
-        console.log("History updated, reloading entries...");
         loadHistoryEntries();
       });
       return unlisten;


### PR DESCRIPTION
## Summary
- Remove leftover `console.log("History updated, reloading entries...")` from the `history-updated` event listener in `HistorySettings.tsx` (line 69)
- This was a debug log left in production code

## Test plan
- [ ] Verify the history-updated event still triggers a reload of history entries without the console.log
- [ ] Confirm no other debug logs remain in the file