### PR TITLE
fix(a11y): correct AlertTitle ref type mismatch

### DIFF
--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -71,7 +71,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
 Alert.displayName = "Alert";
 
 const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h5


### PR DESCRIPTION
## Summary
- Fixed `AlertTitle` ref type from `HTMLParagraphElement` to `HTMLHeadingElement` in `src/components/ui/Alert.tsx`
- The component renders an `<h5>` element, so the ref type should be `HTMLHeadingElement` to match

## Test plan
- [ ] Verify TypeScript compilation passes with no type errors
- [ ] Confirm AlertTitle ref usage works correctly with the updated type