### PR TITLE
fix(a11y): add aria-label to dropdown search input

### DIFF
--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -197,6 +197,7 @@ const SearchableDropdown: React.FC<DropdownProps> = ({
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 onKeyDown={onSearchKeyDown}
+                aria-label={searchPlaceholder || t("common.search")}
                 placeholder={searchPlaceholder || t("common.search")}
                 className="w-full px-2 py-1 text-sm bg-glass-bg border border-glass-border rounded focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent"
               />


### PR DESCRIPTION
## Summary
- Add `aria-label` to the search `<input>` in `SearchableDropdown` to satisfy WCAG 1.3.1 (Info and Relationships, Level A).
- Uses the `searchPlaceholder` prop when provided, otherwise falls back to the i18n `t("common.search")` string.

## Test plan
- [ ] Open any searchable dropdown in the app and verify the search input now has an `aria-label` attribute via browser DevTools or a screen reader.
- [ ] Confirm the label matches the placeholder text.