### PR TITLE
fix: remove unused React.FC annotation from DragRegion

### DIFF
--- a/src/components/ui/DragRegion.tsx
+++ b/src/components/ui/DragRegion.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
-export const DragRegion: React.FC = () => {
+export const DragRegion = () => {
   const appWindow = useMemo(() => getCurrentWindow(), []);
 
   return (


### PR DESCRIPTION
## Summary
- Remove `React.FC` type annotation from `DragRegion` component in `src/components/ui/DragRegion.tsx`
- The component used `React.FC` without an explicit `React` import, relying on the JSX transform. Replaced with a plain arrow function signature for correctness and simplicity.

## Test plan
- [ ] Verify the app builds without TypeScript errors
- [ ] Verify the drag region still works (click and drag the title bar area)