### PR TITLE
fix(a11y): sidebar hover color adapts to theme

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -136,7 +136,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 whileHover={{
                   backgroundColor: isActive
                     ? undefined
-                    : "rgba(255,255,255,0.05)",
+                    : "var(--color-glass-highlight)",
                 }}
                 whileTap={tapScale}
                 transition={spring.snappy}


### PR DESCRIPTION
## Summary
- Replace hard-coded `rgba(255,255,255,0.05)` hover background in `Sidebar.tsx` with `var(--color-glass-highlight)`, which adapts per theme.
- Fixes invisible hover highlight in light mode (white overlay on light background).

## Test plan
- [ ] Verify sidebar button hover shows a visible highlight in light mode
- [ ] Verify sidebar button hover still looks correct in dark mode
- [ ] Confirm active tab does not show the hover overlay