### PR TITLE
fix(a11y): add muted color to SettingContainer inline descriptions

### DIFF
--- a/src/components/ui/SettingContainer.tsx
+++ b/src/components/ui/SettingContainer.tsx
@@ -77,7 +77,7 @@ export const SettingContainer: React.FC<SettingContainerProps> = ({
           <h3 className={`text-sm font-medium ${disabled ? "opacity-50" : ""}`}>
             {title}
           </h3>
-          <p className={`text-sm ${disabled ? "opacity-50" : ""}`}>
+          <p className={`text-sm text-muted-foreground ${disabled ? "opacity-50" : ""}`}>
             {description}
           </p>
         </div>
@@ -126,7 +126,7 @@ export const SettingContainer: React.FC<SettingContainerProps> = ({
         <h3 className={`text-sm font-medium ${disabled ? "opacity-50" : ""}`}>
           {title}
         </h3>
-        <p className={`text-sm ${disabled ? "opacity-50" : ""}`}>
+        <p className={`text-sm text-muted-foreground ${disabled ? "opacity-50" : ""}`}>
           {description}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Add `text-muted-foreground` class to inline-mode description `<p>` elements in `SettingContainer` (lines 80 and 129)
- Inline descriptions now match the muted styling used by tooltip-mode descriptions, instead of inheriting full text color

## Test plan
- [ ] Verify inline-mode descriptions in settings panels render with muted/subdued text color
- [ ] Verify tooltip-mode descriptions remain unchanged
- [ ] Verify disabled state (opacity-50) still applies correctly on top of the muted color