### PR TITLE
fix: replace hard-coded version fallback with "unknown"

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -14,7 +14,7 @@ const Footer: React.FC = () => {
         setVersion(appVersion);
       } catch (error) {
         console.error("Failed to get app version:", error);
-        setVersion("0.1.2");
+        setVersion("unknown");
       }
     };
 

--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -20,7 +20,7 @@ export const AboutSettings: React.FC = () => {
         setVersion(appVersion);
       } catch (error) {
         console.error("Failed to get app version:", error);
-        setVersion("0.1.2");
+        setVersion("unknown");
       }
     };
 


### PR DESCRIPTION
## Summary
- Both `Footer.tsx` and `AboutSettings.tsx` used a hard-coded `"0.1.2"` as the error fallback when fetching the app version via Tauri API.
- This value becomes stale and incorrect for any release after 0.1.2.
- Changed the fallback to `"unknown"` so the UI never displays a wrong version number.

## Test plan
- [ ] Verify the app still displays the correct version in the footer and About settings when the Tauri API call succeeds.
- [ ] Simulate a version fetch failure and confirm "unknown" is displayed instead of a stale version.