### PR TITLE
fix(security): replace dangerouslySetInnerHTML with safe text rendering

### DIFF
--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -320,12 +320,9 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
           className="min-h-[200px] rounded-t-none"
         />
       </div>
-      <p
-        className="text-xs text-muted/70"
-        dangerouslySetInnerHTML={{
-          __html: t("settings.postProcessing.prompts.promptTip"),
-        }}
-      />
+      <p className="text-xs text-muted/70">
+        {t("settings.postProcessing.prompts.promptTip")}
+      </p>
     </>
   );
 


### PR DESCRIPTION
## Summary
- Removes `dangerouslySetInnerHTML` usage in `PostProcessingSettings.tsx` for the prompt tip paragraph, replacing it with safe React text content rendering.
- The translation strings for `promptTip` across all locales contain plain text with no HTML markup, so `dangerouslySetInnerHTML` was unnecessary and introduced an XSS risk if translation strings were ever user-influenced or contained malicious markup.

## Test plan
- [ ] Verify the prompt tip text still renders correctly in the post-processing settings panel
- [ ] Check multiple locales to confirm no formatting is lost