### PR TITLE
fix(a11y): add ARIA semantics to DragRegion

### DIFF
--- a/src/components/ui/DragRegion.tsx
+++ b/src/components/ui/DragRegion.tsx
@@ -6,6 +6,8 @@ export const DragRegion = () => {
 
   return (
     <div
+      role="presentation"
+      aria-hidden="true"
       onMouseDown={(e) => {
         if (e.buttons === 1) appWindow.startDragging();
       }}


### PR DESCRIPTION
## Summary
- Add `role="presentation"` and `aria-hidden="true"` to the DragRegion div
- The drag region is a non-semantic window chrome element (40px-tall invisible draggable area) that should be hidden from screen readers
- Fixes UI audit issue #17

## Test plan
- [ ] Verify the app still allows window dragging via the drag region
- [ ] Verify screen readers no longer announce the drag region div