### PR TITLE
fix(ui): replace hard-coded toaster offset with CSS variable

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -74,6 +74,9 @@
   --glass-blur: 12px;
   --glass-blur-heavy: 24px;
   --glass-blur-light: 6px;
+
+  /* Layout */
+  --sidebar-width: 10rem;
 }
 
 html,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,7 +172,7 @@ function App() {
               position="top-center"
               closeButton
               theme={resolvedTheme}
-              style={{ left: "calc(50% + 80px)" }}
+              style={{ left: "calc(50% + var(--sidebar-width) / 2)" }}
               toastOptions={{
                 unstyled: true,
                 classNames: {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -117,7 +117,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
     .map(([id, config]) => ({ id: id as SidebarSection, ...config }));
 
   return (
-    <div className="flex flex-col w-40 h-full border-e border-glass-border glass-panel-heavy items-center px-2">
+    <div className="flex flex-col h-full border-e border-glass-border glass-panel-heavy items-center px-2" style={{ width: "var(--sidebar-width)" }}>
       <DragRegion />
       <LayoutGroup>
         <div role="tablist" className="flex flex-col w-full items-center gap-1">


### PR DESCRIPTION
## Summary
- Introduced a `--sidebar-width` CSS variable (`10rem`) in `App.css` as a single source of truth for the sidebar width
- Updated `Sidebar.tsx` to use the CSS variable instead of the Tailwind `w-40` class
- Replaced the hard-coded `80px` magic number in the `Toaster` style in `App.tsx` with `calc(... + var(--sidebar-width) / 2)` so the toast center tracks the sidebar width automatically

## Test plan
- [ ] Verify toasts still appear centered over the content area (to the right of the sidebar)
- [ ] Verify the sidebar width remains unchanged visually
- [ ] Change `--sidebar-width` to a different value and confirm both the sidebar and toast position update accordingly