### PR TITLE
fix(a11y): consistent heading hierarchy across settings pages

### DIFF
--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -29,6 +29,7 @@ export const AboutSettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.about")}</h1>
       <SettingsGroup title={t("settings.about.title")}>
         <AppLanguageSelector descriptionMode="tooltip" grouped={true} />
         <SettingContainer

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -21,6 +21,7 @@ export const AdvancedSettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.advanced")}</h1>
       <SettingsGroup title={t("settings.advanced.groups.app")}>
         <ThemeSelector descriptionMode="tooltip" grouped={true} />
         <StartHidden descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/debug/DebugSettings.tsx
+++ b/src/components/settings/debug/DebugSettings.tsx
@@ -20,6 +20,7 @@ export const DebugSettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.debug")}</h1>
       <SettingsGroup title={t("settings.debug.title")}>
         <LogLevelSelector grouped={true} />
         <UpdateChecksToggle descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -15,6 +15,7 @@ export const GeneralSettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.general")}</h1>
       <ModelSettingsCard />
       <SettingsGroup title={t("settings.sound.title")}>
         <MicrophoneSelector descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -146,6 +146,7 @@ export const HistorySettings: React.FC = () => {
   if (loading) {
     return (
       <div className="max-w-3xl w-full mx-auto space-y-4">
+        <h1 className="sr-only">{t("sidebar.history")}</h1>
         {retentionSection}
         <div className="space-y-1.5">
           <div className="px-3 flex items-center justify-between">
@@ -175,6 +176,7 @@ export const HistorySettings: React.FC = () => {
   if (historyEntries.length === 0) {
     return (
       <div className="max-w-3xl w-full mx-auto space-y-4">
+        <h1 className="sr-only">{t("sidebar.history")}</h1>
         {retentionSection}
         <div className="space-y-1.5">
           <div className="px-3 flex items-center justify-between">
@@ -205,6 +207,7 @@ export const HistorySettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.history")}</h1>
       {retentionSection}
       <div className="space-y-1.5">
         <div className="px-3 flex items-center justify-between">

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -445,6 +445,7 @@ export const PostProcessingSettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.postProcessing")}</h1>
       <SettingsGroup title={t("settings.postProcessing.api.title")}>
         <PostProcessingSettingsApi />
         {statsLine && (

--- a/src/components/settings/shortcuts/ShortcutsSettings.tsx
+++ b/src/components/settings/shortcuts/ShortcutsSettings.tsx
@@ -8,6 +8,7 @@ export const ShortcutsSettings: React.FC = () => {
   const { t } = useTranslation();
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.shortcuts")}</h1>
       <ShortcutBindingsCard />
       <SettingsGroup title={t("settings.general.title")}>
         <PushToTalk descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/stats/StatsSettings.tsx
+++ b/src/components/settings/stats/StatsSettings.tsx
@@ -313,6 +313,7 @@ export const StatsSettings: React.FC = () => {
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-4">
+      <h1 className="sr-only">{t("sidebar.stats")}</h1>
       <div className="space-y-3">
         <div className="px-3">
           <h2 className="text-xs font-medium text-muted uppercase tracking-wide">


### PR DESCRIPTION
## Summary
- Add visually hidden (`sr-only`) `h1` page titles to all settings pages that were missing them (General, Shortcuts, Post-Processing, History, Stats, Advanced, About, Debug)
- This fixes heading level skips where pages jumped from no `h1` directly to `h2` (SettingsGroup) and `h3` (SettingContainer)
- Every settings page now follows the hierarchy: `h1` (page title) > `h2` (section) > `h3` (sub-section), consistent with ModelsSettings which already had a visible `h1`
- WCAG 1.3.1 Info and Relationships (Level A)

Closes #13

## Test plan
- [ ] Verify screen readers announce the page title (h1) when navigating to each settings tab
- [ ] Verify no visual changes — the h1 elements use Tailwind's `sr-only` class and are invisible
- [ ] Verify heading hierarchy with a browser accessibility inspector (no skipped levels on any settings page)