### PR TITLE
style(ui): warm palette, flatter surfaces, subtler motion

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,14 +24,14 @@
   --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, monospace;
 
   /* App palette — used directly (bg-accent, text-muted, etc.) */
-  --color-text: #fafafa;
-  --color-background: #050505;
-  --color-surface: #141414;
+  --color-text: #f5f0eb;
+  --color-background: #080604;
+  --color-surface: #151210;
   --color-accent: #ef6f2f;
-  --color-muted: #8a8380;
-  --color-border: rgba(250, 250, 250, 0.08);
-  --color-background-translucent: rgba(18, 18, 18, 0.35);
-  --color-surface-translucent: rgba(30, 30, 30, 0.25);
+  --color-muted: #9a9390;
+  --color-border: rgba(200, 170, 140, 0.08);
+  --color-background-translucent: rgba(18, 14, 12, 0.35);
+  --color-surface-translucent: rgba(30, 25, 22, 0.25);
   --color-error: #ff5f57;
   --color-warning: #febc2e;
   --color-success: #28c840;
@@ -57,19 +57,16 @@
   --radius: 12px;
 
   /* Glass tokens */
-  --color-glass-bg: rgba(255, 255, 255, 0.04);
-  --color-glass-border: rgba(255, 255, 255, 0.08);
-  --color-glass-border-hover: rgba(255, 255, 255, 0.14);
-  --color-glass-highlight: rgba(255, 255, 255, 0.06);
+  --color-glass-bg: rgba(200, 170, 140, 0.04);
+  --color-glass-border: rgba(200, 170, 140, 0.08);
+  --color-glass-border-hover: rgba(200, 170, 140, 0.14);
+  --color-glass-highlight: rgba(200, 170, 140, 0.06);
 
-  --shadow-glass:
-    0 2px 8px rgba(0, 0, 0, 0.2), 0 0 0 0.5px rgba(255, 255, 255, 0.06);
-  --shadow-glass-hover:
-    0 4px 16px rgba(0, 0, 0, 0.25), 0 0 0 0.5px rgba(255, 255, 255, 0.1);
-  --shadow-glass-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  --shadow-accent-glow: 0 0 12px rgba(239, 111, 47, 0.25);
+  --shadow-glass: 0 1px 3px rgba(0, 0, 0, 0.12);
+  --shadow-glass-hover: 0 2px 8px rgba(0, 0, 0, 0.18);
+  --shadow-accent-glow: 0 0 4px rgba(239, 111, 47, 0.1);
 
-  --color-glass-bg-solid: #1e1e1e;
+  --color-glass-bg-solid: #1c1916;
 
   --glass-blur: 12px;
   --glass-blur-heavy: 24px;
@@ -105,22 +102,22 @@ body {
 
   /* Apply colors */
   color: var(--color-text);
-  background-color: rgba(5, 5, 5, 0.88);
+  background-color: rgba(8, 6, 4, 0.88);
 }
 
 :root[data-theme="light"] {
-  background-color: rgba(255, 255, 255, 0.92);
+  background-color: rgba(253, 251, 249, 0.92);
 }
 
 @layer base {
   :root[data-theme="light"] {
     color-scheme: light;
-    --color-text: #1a1a1a;
-    --color-background: #ffffff;
+    --color-text: #1c1714;
+    --color-background: #fdfbf9;
     --color-surface: #f5f3f1;
     --color-muted: #6b6462;
-    --color-border: rgba(0, 0, 0, 0.1);
-    --color-background-translucent: rgba(255, 255, 255, 0.65);
+    --color-border: rgba(80, 50, 20, 0.1);
+    --color-background-translucent: rgba(253, 251, 249, 0.65);
     --color-surface-translucent: rgba(245, 243, 241, 0.7);
     --color-error: #dc3d35;
     --color-warning: #b58300;
@@ -128,28 +125,25 @@ body {
     --color-info: #2563eb;
     /* accent stays #ef6f2f — brand color, used on buttons with white text */
 
-    --color-glass-bg: rgba(0, 0, 0, 0.03);
-    --color-glass-bg-solid: #eae8e6;
-    --color-glass-border: rgba(0, 0, 0, 0.08);
-    --color-glass-border-hover: rgba(0, 0, 0, 0.14);
-    --color-glass-highlight: rgba(0, 0, 0, 0.04);
+    --color-glass-bg: rgba(80, 50, 20, 0.03);
+    --color-glass-bg-solid: #eae6e2;
+    --color-glass-border: rgba(80, 50, 20, 0.08);
+    --color-glass-border-hover: rgba(80, 50, 20, 0.14);
+    --color-glass-highlight: rgba(80, 50, 20, 0.04);
 
-    --shadow-glass:
-      0 2px 8px rgba(0, 0, 0, 0.06), 0 0 0 0.5px rgba(0, 0, 0, 0.05);
-    --shadow-glass-hover:
-      0 4px 16px rgba(0, 0, 0, 0.1), 0 0 0 0.5px rgba(0, 0, 0, 0.08);
-    --shadow-glass-inset: inset 0 1px 0 rgba(255, 255, 255, 0.5);
-    --shadow-accent-glow: 0 0 12px rgba(239, 111, 47, 0.2);
+    --shadow-glass: 0 1px 3px rgba(0, 0, 0, 0.06);
+    --shadow-glass-hover: 0 2px 8px rgba(0, 0, 0, 0.1);
+    --shadow-accent-glow: 0 0 4px rgba(239, 111, 47, 0.1);
   }
 }
 
-/* ── Glass utility classes ─────────────────────────────────────── */
+/* ── Glass utility classes (reserved for elevated/floating elements) ── */
 .glass-panel {
   background: var(--color-glass-bg);
   border: 1px solid var(--color-glass-border);
   backdrop-filter: blur(var(--glass-blur));
   -webkit-backdrop-filter: blur(var(--glass-blur));
-  box-shadow: var(--shadow-glass), var(--shadow-glass-inset);
+  box-shadow: var(--shadow-glass);
 }
 
 .glass-panel-heavy {
@@ -157,7 +151,7 @@ body {
   border: 1px solid var(--color-glass-border);
   backdrop-filter: blur(var(--glass-blur-heavy));
   -webkit-backdrop-filter: blur(var(--glass-blur-heavy));
-  box-shadow: var(--shadow-glass), var(--shadow-glass-inset);
+  box-shadow: var(--shadow-glass);
 }
 
 .glass-panel-light {
@@ -165,7 +159,6 @@ body {
   border: 1px solid var(--color-glass-border);
   backdrop-filter: blur(var(--glass-blur-light));
   -webkit-backdrop-filter: blur(var(--glass-blur-light));
-  box-shadow: var(--shadow-glass-inset);
 }
 
 .container {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -144,17 +144,17 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 {isActive && (
                   <motion.div
                     layoutId="sidebar-active-indicator"
-                    className="absolute inset-0 rounded-lg bg-accent/80"
+                    className="absolute inset-y-1 left-0 w-[3px] rounded-full bg-accent"
                     transition={spring.snappy}
                   />
                 )}
                 <Icon
                   size={18}
-                  weight="light"
-                  className={`shrink-0 relative z-10 ${!isActive ? "opacity-85" : ""}`}
+                  weight={isActive ? "regular" : "light"}
+                  className={`shrink-0 relative z-10 ${isActive ? "text-accent" : "text-muted"}`}
                 />
                 <p
-                  className={`text-sm font-medium truncate relative z-10 ${!isActive ? "opacity-85" : ""}`}
+                  className={`text-sm truncate relative z-10 ${isActive ? "font-semibold" : "font-medium text-muted"}`}
                 >
                   {t(section.labelKey)}
                 </p>

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -22,8 +22,8 @@ const Footer: React.FC = () => {
   }, []);
 
   return (
-    <div className="w-full border-t border-glass-border bg-glass-bg backdrop-blur-sm pt-3">
-      <div className="flex justify-between items-center text-xs px-4 pb-3 text-text/60">
+    <div className="w-full border-t border-glass-border bg-glass-bg pt-2">
+      <div className="flex justify-between items-center text-xs px-4 pb-2 text-text/60">
         <div className="flex items-center gap-4">
           <ModelSelector />
         </div>

--- a/src/components/model-selector/ModelDropdown.tsx
+++ b/src/components/model-selector/ModelDropdown.tsx
@@ -24,7 +24,7 @@ const DropdownItem: React.FC<DropdownItemProps> = ({
       className={`w-full text-start px-3 py-2 rounded-md transition-colors cursor-pointer focus:outline-none ${
         active
           ? "bg-accent/10 text-text"
-          : "text-text/70 hover:bg-white/5 hover:text-text"
+          : "text-text/70 hover:bg-glass-highlight hover:text-text"
       }`}
     >
       <div className="flex items-center justify-between gap-2">

--- a/src/components/onboarding/AccessibilityOnboarding.tsx
+++ b/src/components/onboarding/AccessibilityOnboarding.tsx
@@ -49,7 +49,7 @@ const PermissionRow: React.FC<{
             className="text-xs text-success/80 flex items-center gap-1.5"
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
-            transition={spring.bouncy}
+            transition={spring.stiff}
           >
             <Check weight="bold" className="w-3.5 h-3.5" />
             {t("onboarding.permissions.granted")}
@@ -250,7 +250,7 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
           <motion.div
             initial={{ scale: 0, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
-            transition={spring.bouncy}
+            transition={spring.stiff}
           >
             <Check weight="bold" className="w-8 h-8 text-success/70" />
           </motion.div>

--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -28,7 +28,7 @@ export const AboutSettings: React.FC = () => {
   }, []);
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.about")}</h1>
       <SettingsGroup title={t("settings.about.title")}>
         <AppLanguageSelector descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -20,7 +20,7 @@ export const AdvancedSettings: React.FC = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.advanced")}</h1>
       <SettingsGroup title={t("settings.advanced.groups.app")}>
         <ThemeSelector descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/debug/DebugSettings.tsx
+++ b/src/components/settings/debug/DebugSettings.tsx
@@ -19,7 +19,7 @@ export const DebugSettings: React.FC = () => {
   const isLinux = type() === "linux";
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.debug")}</h1>
       <SettingsGroup title={t("settings.debug.title")}>
         <LogLevelSelector grouped={true} />

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -14,7 +14,7 @@ export const GeneralSettings: React.FC = () => {
   const { audioFeedbackEnabled } = useSettings();
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.general")}</h1>
       <ModelSettingsCard />
       <SettingsGroup title={t("settings.sound.title")}>

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -145,7 +145,7 @@ export const HistorySettings: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="max-w-3xl w-full mx-auto space-y-4">
+      <div className="max-w-3xl w-full mx-auto space-y-6">
         <h1 className="sr-only">{t("sidebar.history")}</h1>
         {retentionSection}
         <div className="space-y-1.5">
@@ -160,7 +160,7 @@ export const HistorySettings: React.FC = () => {
               label={t("settings.history.openFolder")}
             />
           </div>
-          <div className="bg-background-translucent backdrop-blur-sm border border-muted/20 rounded overflow-visible">
+          <div className="bg-background-translucent border border-muted/20 rounded overflow-visible">
             <div className="px-3 py-8 flex flex-col items-center gap-3">
               <div className="w-5 h-5 border-2 border-muted/40 border-t-accent rounded-full animate-spin" />
               <p className="text-sm text-muted">
@@ -175,7 +175,7 @@ export const HistorySettings: React.FC = () => {
 
   if (historyEntries.length === 0) {
     return (
-      <div className="max-w-3xl w-full mx-auto space-y-4">
+      <div className="max-w-3xl w-full mx-auto space-y-6">
         <h1 className="sr-only">{t("sidebar.history")}</h1>
         {retentionSection}
         <div className="space-y-1.5">
@@ -190,7 +190,7 @@ export const HistorySettings: React.FC = () => {
               label={t("settings.history.openFolder")}
             />
           </div>
-          <div className="bg-background-translucent backdrop-blur-sm border border-muted/20 rounded overflow-visible">
+          <div className="bg-background-translucent border border-muted/20 rounded overflow-visible">
             <div className="px-3 py-10 flex flex-col items-center gap-3">
               <div className="w-10 h-10 rounded-full bg-muted/10 flex items-center justify-center">
                 <Microphone className="w-5 h-5 text-muted/60" />
@@ -206,7 +206,7 @@ export const HistorySettings: React.FC = () => {
   }
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.history")}</h1>
       {retentionSection}
       <div className="space-y-1.5">

--- a/src/components/settings/models/LibraryTab.tsx
+++ b/src/components/settings/models/LibraryTab.tsx
@@ -105,7 +105,7 @@ export const LibraryTab: React.FC = () => {
     <div className="space-y-4">
       {cloudProviders.length > 0 && (
         <div className="space-y-2">
-          <h2 className="text-sm font-medium text-text/60">
+          <h2 className="text-sm font-semibold text-muted-foreground">
             {t("settings.models.cloudProviders.title")}
           </h2>
           {cloudProviders.map((provider) => (
@@ -143,7 +143,7 @@ export const LibraryTab: React.FC = () => {
 
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-medium text-text/60">
+          <h2 className="text-sm font-semibold text-muted-foreground">
             {t("settings.models.localModels.title")}
           </h2>
           <LanguageFilter value={languageFilter} onChange={setLanguageFilter} />

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -22,12 +22,12 @@ export const ModelsSettings: React.FC = () => {
   }
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <div className="mb-4">
         <h1 className="text-xl font-semibold mb-2">
           {t("settings.models.title")}
         </h1>
-        <p className="text-sm text-text/60">
+        <p className="text-sm text-muted-foreground">
           {t("settings.models.description")}
         </p>
       </div>

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -444,7 +444,7 @@ export const PostProcessingSettings: React.FC = () => {
     : null;
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.postProcessing")}</h1>
       <SettingsGroup title={t("settings.postProcessing.api.title")}>
         <PostProcessingSettingsApi />

--- a/src/components/settings/shortcuts/ShortcutsSettings.tsx
+++ b/src/components/settings/shortcuts/ShortcutsSettings.tsx
@@ -7,7 +7,7 @@ import { ShortcutBindingsCard } from "../general/ShortcutBindingsCard";
 export const ShortcutsSettings: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.shortcuts")}</h1>
       <ShortcutBindingsCard />
       <SettingsGroup title={t("settings.general.title")}>

--- a/src/components/settings/stats/StatsSettings.tsx
+++ b/src/components/settings/stats/StatsSettings.tsx
@@ -60,7 +60,7 @@ function StatCard({
   subLabel: string;
 }) {
   return (
-    <div className="bg-background-translucent backdrop-blur-sm border border-glass-border rounded px-3 py-2.5">
+    <div className="bg-background-translucent border border-glass-border rounded px-3 py-2.5">
       <div className="flex items-center gap-1.5 mb-1">
         <IconComponent size={12} className="text-muted" />
         <span className="text-[10px] text-muted uppercase tracking-wide">
@@ -198,7 +198,7 @@ export const StatsSettings: React.FC = () => {
   let content;
   if (loading) {
     content = (
-      <div className="bg-background-translucent backdrop-blur-sm border border-glass-border rounded">
+      <div className="bg-background-translucent border border-glass-border rounded">
         <div className="px-3 py-8 flex flex-col items-center gap-3">
           <div className="w-5 h-5 border-2 border-muted/40 border-t-accent rounded-full animate-spin" />
         </div>
@@ -206,7 +206,7 @@ export const StatsSettings: React.FC = () => {
     );
   } else if (stats.length === 0) {
     content = (
-      <div className="bg-background-translucent backdrop-blur-sm border border-glass-border rounded">
+      <div className="bg-background-translucent border border-glass-border rounded">
         <div className="px-3 py-10 flex flex-col items-center gap-3">
           <div className="w-10 h-10 rounded-full bg-muted/10 flex items-center justify-center">
             <Speedometer className="w-5 h-5 text-muted" />
@@ -255,7 +255,7 @@ export const StatsSettings: React.FC = () => {
               {t("settings.stats.wpmOverTime")}
             </h3>
           </div>
-          <div className="bg-background-translucent backdrop-blur-sm border border-glass-border rounded px-3 py-4">
+          <div className="bg-background-translucent border border-glass-border rounded px-3 py-4">
             <ResponsiveContainer width="100%" height={200}>
               <LineChart data={chartData}>
                 <XAxis
@@ -312,7 +312,7 @@ export const StatsSettings: React.FC = () => {
   }
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-4">
+    <div className="max-w-3xl w-full mx-auto space-y-6">
       <h1 className="sr-only">{t("sidebar.stats")}</h1>
       <div className="space-y-3">
         <div className="px-3">

--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -9,18 +9,18 @@ import {
 import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm backdrop-blur-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>div]:pl-7",
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>div]:pl-7",
   {
     variants: {
       variant: {
         default: "bg-glass-bg border-glass-border text-foreground",
         destructive:
-          "border-destructive/30 text-destructive bg-destructive/10 backdrop-blur-sm [&>svg]:text-destructive",
+          "border-destructive/30 text-destructive bg-destructive/10 [&>svg]:text-destructive",
         warning:
-          "border-warning/30 text-warning bg-warning/10 backdrop-blur-sm [&>svg]:text-warning",
-        info: "border-info/30 text-info bg-info/10 backdrop-blur-sm [&>svg]:text-info",
+          "border-warning/30 text-warning bg-warning/10 [&>svg]:text-warning",
+        info: "border-info/30 text-info bg-info/10 [&>svg]:text-info",
         success:
-          "border-success/30 text-success bg-success/10 backdrop-blur-sm [&>svg]:text-success",
+          "border-success/30 text-success bg-success/10 [&>svg]:text-success",
       },
     },
     defaultVariants: {

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold backdrop-blur-sm transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -14,14 +14,14 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/80",
         outline:
-          "border border-glass-border bg-glass-bg backdrop-blur-sm shadow-glass hover:bg-glass-highlight hover:border-glass-border-hover hover:shadow-glass-hover",
+          "border border-glass-border bg-glass-bg hover:bg-glass-highlight hover:border-glass-border-hover",
         secondary:
-          "bg-glass-bg text-secondary-foreground shadow-glass border border-glass-border backdrop-blur-sm hover:bg-primary/20 hover:border-primary",
+          "bg-glass-bg text-secondary-foreground border border-glass-border hover:bg-primary/20 hover:border-primary",
         ghost:
           "hover:bg-muted-foreground/10 hover:border-primary border border-transparent",
         link: "text-primary underline-offset-4 hover:underline",
         glass:
-          "bg-glass-bg border border-glass-border backdrop-blur-sm shadow-glass hover:bg-glass-highlight hover:border-glass-border-hover hover:shadow-glass-hover",
+          "bg-glass-bg border border-glass-border hover:bg-glass-highlight hover:border-glass-border-hover",
         "primary-soft":
           "text-text bg-primary/20 border border-transparent hover:bg-primary/30",
         "danger-ghost":

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -138,7 +138,7 @@ const SearchableDropdown: React.FC<DropdownProps> = ({
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         className={cn(
-          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded backdrop-blur-sm",
+          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded",
           "min-w-[160px] text-start flex items-center justify-between",
           "transition-all duration-150",
           disabled
@@ -279,7 +279,7 @@ const SimpleDropdown: React.FC<DropdownProps> = ({
     >
       <SelectPrimitive.Trigger
         className={cn(
-          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded backdrop-blur-sm",
+          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded",
           "min-w-[160px] text-start flex items-center justify-between",
           "transition-all duration-150",
           disabled

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const inputVariants = cva(
-  "flex w-full rounded-md border border-glass-border bg-glass-bg backdrop-blur-sm text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:shadow-accent-glow disabled:cursor-not-allowed disabled:opacity-50",
+  "flex w-full rounded-md border border-glass-border bg-glass-bg text-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/src/components/ui/MultiSelectDropdown.tsx
+++ b/src/components/ui/MultiSelectDropdown.tsx
@@ -88,7 +88,7 @@ export const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         className={cn(
-          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded backdrop-blur-sm",
+          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded",
           "min-w-[160px] text-start flex items-center justify-between gap-1",
           "transition-all duration-150",
           disabled

--- a/src/components/ui/NumberInput.tsx
+++ b/src/components/ui/NumberInput.tsx
@@ -38,7 +38,7 @@ const NumberInput = React.forwardRef<HTMLDivElement, NumberInputProps>(
       <div
         ref={ref}
         className={cn(
-          "inline-flex items-center rounded-md border border-glass-border bg-glass-bg backdrop-blur-sm shadow-sm",
+          "inline-flex items-center rounded-md border border-glass-border bg-glass-bg shadow-sm",
           disabled && "opacity-50 pointer-events-none",
           className,
         )}

--- a/src/components/ui/PathDisplay.tsx
+++ b/src/components/ui/PathDisplay.tsx
@@ -17,7 +17,7 @@ export const PathDisplay: React.FC<PathDisplayProps> = ({
 
   return (
     <div className="flex items-center gap-2">
-      <div className="flex-1 min-w-0 px-2 py-2 bg-glass-bg border border-glass-border rounded-lg backdrop-blur-sm text-xs font-mono break-all select-text cursor-text">
+      <div className="flex-1 min-w-0 px-2 py-2 bg-glass-bg border border-glass-border rounded-lg text-xs font-mono break-all select-text cursor-text">
         {path}
       </div>
       <Button

--- a/src/components/ui/ResetButton.tsx
+++ b/src/components/ui/ResetButton.tsx
@@ -17,7 +17,7 @@ export const ResetButton: React.FC<ResetButtonProps> = React.memo(
       className={`p-1 rounded-lg border border-transparent transition-all duration-150 ${
         disabled
           ? "opacity-50 cursor-not-allowed text-text/40"
-          : "hover:bg-accent/30 hover:shadow-accent-glow active:bg-accent/50 active:translate-y-[1px] hover:cursor-pointer hover:border-accent text-text/80"
+          : "hover:bg-accent/30 active:bg-accent/50 active:translate-y-[1px] hover:cursor-pointer hover:border-accent text-text/80"
       } ${className}`}
       onClick={onClick}
       disabled={disabled}

--- a/src/components/ui/SelectableCard.tsx
+++ b/src/components/ui/SelectableCard.tsx
@@ -24,11 +24,11 @@ export const SelectableCard: React.FC<SelectableCardProps> = ({
   children,
 }) => {
   const baseClasses = compact
-    ? "flex flex-col rounded-xl px-3 py-2 gap-1 text-left transition-all duration-200 backdrop-blur-sm"
-    : "flex flex-col rounded-xl px-4 py-3 gap-2 text-left transition-all duration-200 backdrop-blur-sm";
+    ? "flex flex-col rounded-xl px-3 py-2 gap-1 text-left transition-all duration-200"
+    : "flex flex-col rounded-xl px-4 py-3 gap-2 text-left transition-all duration-200";
 
   const variantClasses = active
-    ? "border-2 border-accent/50 bg-accent/10 shadow-accent-glow"
+    ? "border-2 border-accent/50 bg-accent/10"
     : featured
       ? "border-2 border-accent/25 bg-glass-bg"
       : "border-2 border-glass-border bg-glass-bg";
@@ -37,7 +37,7 @@ export const SelectableCard: React.FC<SelectableCardProps> = ({
     ? ""
     : disabled
       ? "opacity-50 cursor-not-allowed"
-      : "cursor-pointer hover:border-accent/50 hover:bg-accent/5 hover:shadow-glass-hover group [&_p]:cursor-text [&_h3]:cursor-text";
+      : "cursor-pointer hover:border-accent/50 hover:bg-accent/5 group [&_p]:cursor-text [&_h3]:cursor-text";
 
   const handleClick = () => {
     if (clickable && !disabled && onClick) {

--- a/src/components/ui/SettingContainer.tsx
+++ b/src/components/ui/SettingContainer.tsx
@@ -41,7 +41,7 @@ export const SettingContainer: React.FC<SettingContainerProps> = ({
 }) => {
   const containerClasses = grouped
     ? "px-3 py-1.5"
-    : "px-3 py-1.5 rounded-xl glass-panel";
+    : "px-3 py-1.5 rounded-xl border border-glass-border";
 
   if (layout === "stacked") {
     if (descriptionMode === "tooltip") {
@@ -89,7 +89,7 @@ export const SettingContainer: React.FC<SettingContainerProps> = ({
   // Horizontal layout (default)
   const horizontalContainerClasses = grouped
     ? "flex items-center justify-between px-3 py-1.5"
-    : "flex items-center justify-between px-3 py-1.5 rounded-xl glass-panel";
+    : "flex items-center justify-between px-3 py-1.5 rounded-xl border border-glass-border";
 
   if (descriptionMode === "tooltip") {
     return (

--- a/src/components/ui/SettingsGroup.tsx
+++ b/src/components/ui/SettingsGroup.tsx
@@ -17,16 +17,16 @@ export const SettingsGroup: React.FC<SettingsGroupProps> = ({
     <div className="space-y-1.5">
       {title && (
         <div className="px-3">
-          <h2 className="text-xs font-medium text-muted uppercase tracking-wide">
+          <h2 className="text-sm font-semibold text-muted-foreground">
             {title}
           </h2>
           {description && (
-            <p className="text-xs text-muted mt-1">{description}</p>
+            <p className="text-xs text-muted mt-0.5">{description}</p>
           )}
         </div>
       )}
       <motion.div
-        className="glass-panel rounded-xl overflow-visible"
+        className="rounded-xl overflow-visible border border-glass-border"
         variants={staggerContainer}
         initial="initial"
         animate="animate"

--- a/src/components/ui/Switch.tsx
+++ b/src/components/ui/Switch.tsx
@@ -12,7 +12,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitive.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-glass-border bg-glass-bg backdrop-blur-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary/50 data-[state=checked]:shadow-accent-glow data-[state=unchecked]:bg-muted-foreground/20",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-glass-border bg-glass-bg shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary/50 data-[state=unchecked]:bg-muted-foreground/20",
       className,
     )}
     {...props}

--- a/src/components/ui/TextDisplay.tsx
+++ b/src/components/ui/TextDisplay.tsx
@@ -58,7 +58,7 @@ export const TextDisplay: React.FC<TextDisplayProps> = ({
       <div className="flex items-center space-x-2">
         <div className="flex-1 min-w-0">
           <div
-            className={`px-2 min-h-8 flex items-center bg-glass-bg border border-glass-border rounded-lg backdrop-blur-sm text-xs ${textClasses} ${!value ? "opacity-60" : ""}`}
+            className={`px-2 min-h-8 flex items-center bg-glass-bg border border-glass-border rounded-lg text-xs ${textClasses} ${!value ? "opacity-60" : ""}`}
           >
             {displayValue}
           </div>
@@ -67,7 +67,7 @@ export const TextDisplay: React.FC<TextDisplayProps> = ({
           <SimpleTooltip content={t("common.copyToClipboard")}>
             <button
               onClick={handleCopy}
-              className="flex items-center justify-center px-2 py-1 w-12 min-h-8 text-xs font-semibold bg-glass-bg hover:bg-accent/10 border border-glass-border hover:border-accent hover:text-accent rounded-lg backdrop-blur-sm transition-all duration-150 flex-shrink-0 cursor-pointer"
+              className="flex items-center justify-center px-2 py-1 w-12 min-h-8 text-xs font-semibold bg-glass-bg hover:bg-accent/10 border border-glass-border hover:border-accent hover:text-accent rounded-lg transition-all duration-150 flex-shrink-0 cursor-pointer"
             >
               {showCopied ? (
                 <div className="flex items-center space-x-1">

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const textareaVariants = cva(
-  "flex w-full rounded-md border border-glass-border bg-glass-bg backdrop-blur-sm text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:shadow-accent-glow disabled:cursor-not-allowed disabled:opacity-50 resize-y",
+  "flex w-full rounded-md border border-glass-border bg-glass-bg text-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-y",
   {
     variants: {
       variant: {

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -4,7 +4,7 @@ import type { Transition, Variants } from "motion/react";
 export const spring = {
   gentle: { type: "spring", stiffness: 120, damping: 20 } as Transition,
   snappy: { type: "spring", stiffness: 300, damping: 25 } as Transition,
-  bouncy: { type: "spring", stiffness: 400, damping: 15 } as Transition,
+  stiff: { type: "spring", stiffness: 400, damping: 30 } as Transition,
 };
 
 // ── Micro-interaction presets ───────────────────────────────────────
@@ -13,9 +13,9 @@ export const hoverLift = { y: -2, transition: spring.gentle };
 
 // ── Page / section transition variants ─────────────────────────────
 export const pageVariants: Variants = {
-  initial: { opacity: 0, y: 8, filter: "blur(4px)" },
+  initial: { opacity: 0, y: 6, filter: "blur(2px)" },
   animate: { opacity: 1, y: 0, filter: "blur(0px)" },
-  exit: { opacity: 0, y: -4, filter: "blur(4px)" },
+  exit: { opacity: 0, y: -3, filter: "blur(2px)" },
 };
 
 export const pageTransition: Transition = {
@@ -26,10 +26,10 @@ export const pageTransition: Transition = {
 // ── Stagger container / item variants ──────────────────────────────
 export const staggerContainer: Variants = {
   initial: {},
-  animate: { transition: { staggerChildren: 0.05 } },
+  animate: { transition: { staggerChildren: 0.04 } },
 };
 
 export const staggerItem: Variants = {
-  initial: { opacity: 0, y: 8 },
+  initial: { opacity: 0, y: 4 },
   animate: { opacity: 1, y: 0, transition: spring.gentle },
 };


### PR DESCRIPTION
## Summary
- Shift color tokens from neutral gray to warm-tinted values (brown/amber undertones) across both dark and light themes
- Remove `backdrop-blur-sm` and inset shadows from ~15 non-floating UI components (buttons, inputs, dropdowns, badges, alerts, switches, etc.) to flatten visual hierarchy
- Replace sidebar active indicator from full background fill to a left accent bar with icon/text color differentiation
- Increase settings page section spacing (`space-y-4` → `space-y-6`) and restyle group headings from uppercase `text-xs` to `text-sm font-semibold`
- Rename `bouncy` spring to `stiff` (damping 15→30), reduce page transition blur/offset, tighten stagger timing
- Remove `--shadow-glass-inset` token and simplify shadow definitions

## Test plan
- [ ] Verify dark theme colors appear warm-tinted, not pure gray
- [ ] Verify light theme colors appear warm-tinted
- [ ] Check sidebar active indicator renders as a left accent bar
- [ ] Confirm no backdrop-blur on inline UI components (buttons, inputs, dropdowns)
- [ ] Verify settings pages have proper spacing between groups
- [ ] Test page transitions and stagger animations feel smooth and non-bouncy
- [ ] Check onboarding permission granted animation uses stiffer spring