### PR TITLE
style(ui): amplify visual confidence across the design system

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -57,14 +57,14 @@
   --radius: 12px;
 
   /* Glass tokens */
-  --color-glass-bg: rgba(200, 170, 140, 0.04);
-  --color-glass-border: rgba(200, 170, 140, 0.08);
-  --color-glass-border-hover: rgba(200, 170, 140, 0.14);
-  --color-glass-highlight: rgba(200, 170, 140, 0.06);
+  --color-glass-bg: rgba(200, 170, 140, 0.06);
+  --color-glass-border: rgba(200, 170, 140, 0.12);
+  --color-glass-border-hover: rgba(200, 170, 140, 0.20);
+  --color-glass-highlight: rgba(200, 170, 140, 0.10);
 
-  --shadow-glass: 0 1px 3px rgba(0, 0, 0, 0.12);
-  --shadow-glass-hover: 0 2px 8px rgba(0, 0, 0, 0.18);
-  --shadow-accent-glow: 0 0 4px rgba(239, 111, 47, 0.1);
+  --shadow-glass: 0 1px 4px rgba(0, 0, 0, 0.16), 0 0 1px rgba(0, 0, 0, 0.1);
+  --shadow-glass-hover: 0 4px 16px rgba(0, 0, 0, 0.22), 0 0 1px rgba(0, 0, 0, 0.1);
+  --shadow-accent-glow: 0 0 8px rgba(239, 111, 47, 0.18), 0 0 2px rgba(239, 111, 47, 0.1);
 
   --color-glass-bg-solid: #1c1916;
 
@@ -125,15 +125,15 @@ body {
     --color-info: #2563eb;
     /* accent stays #ef6f2f — brand color, used on buttons with white text */
 
-    --color-glass-bg: rgba(80, 50, 20, 0.03);
+    --color-glass-bg: rgba(80, 50, 20, 0.05);
     --color-glass-bg-solid: #eae6e2;
-    --color-glass-border: rgba(80, 50, 20, 0.08);
-    --color-glass-border-hover: rgba(80, 50, 20, 0.14);
-    --color-glass-highlight: rgba(80, 50, 20, 0.04);
+    --color-glass-border: rgba(80, 50, 20, 0.11);
+    --color-glass-border-hover: rgba(80, 50, 20, 0.18);
+    --color-glass-highlight: rgba(80, 50, 20, 0.08);
 
-    --shadow-glass: 0 1px 3px rgba(0, 0, 0, 0.06);
-    --shadow-glass-hover: 0 2px 8px rgba(0, 0, 0, 0.1);
-    --shadow-accent-glow: 0 0 4px rgba(239, 111, 47, 0.1);
+    --shadow-glass: 0 1px 4px rgba(0, 0, 0, 0.08), 0 0 1px rgba(0, 0, 0, 0.05);
+    --shadow-glass-hover: 0 4px 16px rgba(0, 0, 0, 0.12), 0 0 1px rgba(0, 0, 0, 0.06);
+    --shadow-accent-glow: 0 0 8px rgba(239, 111, 47, 0.14), 0 0 2px rgba(239, 111, 47, 0.08);
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -195,7 +195,7 @@ function App() {
               <div className="flex-1 flex flex-col overflow-hidden">
                 <DragRegion />
                 <div className="flex-1 overflow-y-auto overscroll-contain">
-                  <div className="flex flex-col items-center p-4 gap-4">
+                  <div className="flex flex-col items-center p-5 gap-5">
                     <AccessibilityPermissions />
                     <AnimatePresence mode="wait">
                       <motion.div

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -131,7 +131,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 type="button"
                 role="tab"
                 aria-selected={isActive}
-                className="relative flex gap-2 items-center py-1 px-2 w-full rounded-lg cursor-pointer bg-transparent border-none text-inherit text-left"
+                className="relative flex gap-2.5 items-center py-1.5 px-2.5 w-full rounded-lg cursor-pointer bg-transparent border-none text-inherit text-left"
                 onClick={() => onSectionChange(section.id)}
                 whileHover={{
                   backgroundColor: isActive
@@ -142,19 +142,26 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 transition={spring.snappy}
               >
                 {isActive && (
-                  <motion.div
-                    layoutId="sidebar-active-indicator"
-                    className="absolute inset-y-1 left-0 w-[3px] rounded-full bg-accent"
-                    transition={spring.snappy}
-                  />
+                  <>
+                    <motion.div
+                      layoutId="sidebar-active-bg"
+                      className="absolute inset-0 rounded-lg bg-accent/[0.08]"
+                      transition={spring.snappy}
+                    />
+                    <motion.div
+                      layoutId="sidebar-active-indicator"
+                      className="absolute inset-y-1.5 left-0 w-[3px] rounded-full bg-accent shadow-accent-glow"
+                      transition={spring.snappy}
+                    />
+                  </>
                 )}
                 <Icon
-                  size={18}
-                  weight={isActive ? "regular" : "light"}
+                  size={20}
+                  weight={isActive ? "bold" : "regular"}
                   className={`shrink-0 relative z-10 ${isActive ? "text-accent" : "text-muted"}`}
                 />
                 <p
-                  className={`text-sm truncate relative z-10 ${isActive ? "font-semibold" : "font-medium text-muted"}`}
+                  className={`text-sm truncate relative z-10 ${isActive ? "font-bold" : "font-medium text-muted"}`}
                 >
                   {t(section.labelKey)}
                 </p>

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -23,7 +23,7 @@ const Footer: React.FC = () => {
 
   return (
     <div className="w-full border-t border-glass-border bg-glass-bg pt-2">
-      <div className="flex justify-between items-center text-xs px-4 pb-2 text-text/60">
+      <div className="flex justify-between items-center text-xs px-4 pb-2 text-text/70">
         <div className="flex items-center gap-4">
           <ModelSelector />
         </div>

--- a/src/components/onboarding/AccessibilityOnboarding.tsx
+++ b/src/components/onboarding/AccessibilityOnboarding.tsx
@@ -37,10 +37,10 @@ const PermissionRow: React.FC<{
 }> = ({ icon, label, status, onGrant }) => {
   const { t } = useTranslation();
   return (
-    <div className="flex items-center justify-between gap-4 py-3">
+    <div className="flex items-center justify-between gap-4 py-3.5">
       <div className="flex items-center gap-3">
-        <span className="text-text/40">{icon}</span>
-        <span className="text-sm text-text/70">{label}</span>
+        <span className="text-text/50">{icon}</span>
+        <span className="text-sm font-medium text-text/80">{label}</span>
       </div>
       <AnimatePresence mode="wait">
         {status === "granted" ? (
@@ -275,10 +275,10 @@ const AccessibilityOnboarding: React.FC<AccessibilityOnboardingProps> = ({
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4, ease: [0.25, 0.1, 0.25, 1] }}
         >
-          <h1 className="text-2xl font-semibold tracking-tight text-text mb-1">
+          <h1 className="text-3xl font-bold tracking-tight text-text mb-1">
             {t("appName")}
           </h1>
-          <p className="text-xs text-text/30 mb-10">
+          <p className="text-xs text-text/40 mb-10">
             {t("onboarding.permissions.description")}
           </p>
 

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -10,7 +10,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/85 shadow-accent-glow",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/80",
         outline:

--- a/src/components/ui/SettingsGroup.tsx
+++ b/src/components/ui/SettingsGroup.tsx
@@ -14,10 +14,10 @@ export const SettingsGroup: React.FC<SettingsGroupProps> = ({
   children,
 }) => {
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2">
       {title && (
         <div className="px-3">
-          <h2 className="text-sm font-semibold text-muted-foreground">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
             {title}
           </h2>
           {description && (
@@ -26,7 +26,7 @@ export const SettingsGroup: React.FC<SettingsGroupProps> = ({
         </div>
       )}
       <motion.div
-        className="rounded-xl overflow-visible border border-glass-border"
+        className="rounded-xl overflow-visible border border-glass-border shadow-glass"
         variants={staggerContainer}
         initial="initial"
         animate="animate"

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -8,28 +8,28 @@ export const spring = {
 };
 
 // ── Micro-interaction presets ───────────────────────────────────────
-export const tapScale = { scale: 0.97 };
-export const hoverLift = { y: -2, transition: spring.gentle };
+export const tapScale = { scale: 0.96 };
+export const hoverLift = { y: -3, transition: spring.gentle };
 
 // ── Page / section transition variants ─────────────────────────────
 export const pageVariants: Variants = {
-  initial: { opacity: 0, y: 6, filter: "blur(2px)" },
+  initial: { opacity: 0, y: 10, filter: "blur(3px)" },
   animate: { opacity: 1, y: 0, filter: "blur(0px)" },
-  exit: { opacity: 0, y: -3, filter: "blur(2px)" },
+  exit: { opacity: 0, y: -5, filter: "blur(3px)" },
 };
 
 export const pageTransition: Transition = {
-  duration: 0.25,
-  ease: [0.25, 0.1, 0.25, 1],
+  duration: 0.3,
+  ease: [0.16, 1, 0.3, 1], // ease-out-expo
 };
 
 // ── Stagger container / item variants ──────────────────────────────
 export const staggerContainer: Variants = {
   initial: {},
-  animate: { transition: { staggerChildren: 0.04 } },
+  animate: { transition: { staggerChildren: 0.06 } },
 };
 
 export const staggerItem: Variants = {
-  initial: { opacity: 0, y: 4 },
+  initial: { opacity: 0, y: 6 },
   animate: { opacity: 1, y: 0, transition: spring.gentle },
 };


### PR DESCRIPTION
## Summary
- **Design tokens**: Increased glass surface opacity (4%→6% bg, 8%→12% border), dual-layer shadows for real depth, and a more prominent warm accent glow on primary elements
- **Motion**: Bolder page transitions (10px offset, ease-out-expo), more noticeable stagger cascade (60ms, 6px), and stronger tap/hover feedback
- **Sidebar**: Active state gets a warm accent background wash + glow on the indicator bar, larger icons (20px), bold weight for active items
- **Settings groups**: Uppercase tracking-wider titles for editorial confidence, shadow-glass on containers
- **Onboarding**: Larger app name (3xl bold), more visible permission row labels
- **Buttons & footer**: Primary buttons glow with accent shadow, footer text bumped to 70% opacity
- **Layout**: Content area padding increased from p-4 to p-5 for more generous breathing room

Both dark and light themes updated proportionally.

## Test plan
- [ ] Verify dark theme: glass surfaces are more visible but not overwhelming
- [ ] Verify light theme: token changes scale proportionally
- [ ] Check sidebar active state: warm background wash + glow bar appear correctly
- [ ] Check settings groups: uppercase titles render cleanly, shadow adds depth
- [ ] Verify onboarding screen: larger heading, readable permission rows
- [ ] Confirm page transitions feel smooth with new ease-out-expo curve
- [ ] Test `prefers-reduced-motion` still respected