### PR TITLE
feat(ui): add Checkbox component and polish settings pages

### DIFF
--- a/src/components/settings/about/AboutSettings.tsx
+++ b/src/components/settings/about/AboutSettings.tsx
@@ -28,7 +28,7 @@ export const AboutSettings: React.FC = () => {
   }, []);
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.about")}</h1>
       <SettingsGroup title={t("settings.about.title")}>
         <AppLanguageSelector descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -20,7 +20,7 @@ export const AdvancedSettings: React.FC = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.advanced")}</h1>
       <SettingsGroup title={t("settings.advanced.groups.app")}>
         <ThemeSelector descriptionMode="tooltip" grouped={true} />

--- a/src/components/settings/advanced/ExportImportSettings.tsx
+++ b/src/components/settings/advanced/ExportImportSettings.tsx
@@ -6,6 +6,7 @@ import { commands } from "@/bindings";
 import type { ImportPreview } from "@/bindings";
 import { SettingContainer } from "../../ui/SettingContainer";
 import { Button } from "../../ui/Button";
+import { Checkbox } from "../../ui/Checkbox";
 import { useSettingsStore } from "@/stores/settingsStore";
 
 export const ExportImportSettings: React.FC = () => {
@@ -125,27 +126,24 @@ export const ExportImportSettings: React.FC = () => {
       >
         {showExportOptions ? (
           <div className="flex items-center gap-2">
-            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+              <Checkbox
                 checked={includeSettings}
-                onChange={(e) => setIncludeSettings(e.target.checked)}
+                onChange={setIncludeSettings}
               />
               {t("settings.advanced.exportData.includeSettings")}
             </label>
-            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+              <Checkbox
                 checked={includeHistory}
-                onChange={(e) => setIncludeHistory(e.target.checked)}
+                onChange={setIncludeHistory}
               />
               {t("settings.advanced.exportData.includeHistory")}
             </label>
-            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+              <Checkbox
                 checked={includeRecordings}
-                onChange={(e) => setIncludeRecordings(e.target.checked)}
+                onChange={setIncludeRecordings}
               />
               {t("settings.advanced.exportData.includeRecordings")}
             </label>
@@ -200,21 +198,19 @@ export const ExportImportSettings: React.FC = () => {
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 {validatedImport.preview.has_settings && (
-                  <label className="flex items-center gap-1.5">
-                    <input
-                      type="checkbox"
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <Checkbox
                       checked={importSettings}
-                      onChange={(e) => setImportSettings(e.target.checked)}
+                      onChange={setImportSettings}
                     />
                     {t("settings.advanced.importData.importSettings")}
                   </label>
                 )}
                 {validatedImport.preview.history_count > 0 && (
-                  <label className="flex items-center gap-1.5">
-                    <input
-                      type="checkbox"
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <Checkbox
                       checked={importHistory}
-                      onChange={(e) => setImportHistory(e.target.checked)}
+                      onChange={setImportHistory}
                     />
                     {t("settings.advanced.importData.historyCount", {
                       count: validatedImport.preview.history_count,
@@ -226,11 +222,10 @@ export const ExportImportSettings: React.FC = () => {
                   </label>
                 )}
                 {validatedImport.preview.recording_files_count > 0 && (
-                  <label className="flex items-center gap-1.5">
-                    <input
-                      type="checkbox"
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <Checkbox
                       checked={importRecordings}
-                      onChange={(e) => setImportRecordings(e.target.checked)}
+                      onChange={setImportRecordings}
                     />
                     {t("settings.advanced.importData.recordingsCount", {
                       count: validatedImport.preview.recording_files_count,

--- a/src/components/settings/debug/DebugSettings.tsx
+++ b/src/components/settings/debug/DebugSettings.tsx
@@ -19,7 +19,7 @@ export const DebugSettings: React.FC = () => {
   const isLinux = type() === "linux";
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.debug")}</h1>
       <SettingsGroup title={t("settings.debug.title")}>
         <LogLevelSelector grouped={true} />

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -14,7 +14,7 @@ export const GeneralSettings: React.FC = () => {
   const { audioFeedbackEnabled } = useSettings();
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.general")}</h1>
       <ModelSettingsCard />
       <SettingsGroup title={t("settings.sound.title")}>

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -145,7 +145,7 @@ export const HistorySettings: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="max-w-3xl w-full mx-auto space-y-6">
+      <div className="max-w-3xl w-full mx-auto space-y-8">
         <h1 className="sr-only">{t("sidebar.history")}</h1>
         {retentionSection}
         <div className="space-y-1.5">
@@ -175,7 +175,7 @@ export const HistorySettings: React.FC = () => {
 
   if (historyEntries.length === 0) {
     return (
-      <div className="max-w-3xl w-full mx-auto space-y-6">
+      <div className="max-w-3xl w-full mx-auto space-y-8">
         <h1 className="sr-only">{t("sidebar.history")}</h1>
         {retentionSection}
         <div className="space-y-1.5">
@@ -206,7 +206,7 @@ export const HistorySettings: React.FC = () => {
   }
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.history")}</h1>
       {retentionSection}
       <div className="space-y-1.5">

--- a/src/components/settings/models/CloudProviderConfigCard.tsx
+++ b/src/components/settings/models/CloudProviderConfigCard.tsx
@@ -9,6 +9,7 @@ import {
   Translate,
   CircleNotch,
 } from "@phosphor-icons/react";
+import { motion } from "motion/react";
 import { ApiKeyField } from "@/components/settings/PostProcessingSettingsApi/ApiKeyField";
 import { Input } from "@/components/ui/Input";
 import Badge from "@/components/ui/Badge";
@@ -21,6 +22,7 @@ import { LANGUAGES } from "@/lib/constants/languages";
 import { getLanguageDisplayText } from "@/lib/utils/modelTranslation";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
+import { Checkbox } from "@/components/ui/Checkbox";
 
 const CloudOptionControl: React.FC<{
   option: CloudProviderOption;
@@ -58,7 +60,7 @@ const CloudOptionControl: React.FC<{
               clearable
               className="w-[200px]"
             />
-            <span className="text-xs text-text/40">
+            <span className="text-xs text-text/50">
               {t("settings.models.cloudProviders.options.selectLanguageHint")}
             </span>
           </div>
@@ -87,7 +89,7 @@ const CloudOptionControl: React.FC<{
         <div className="flex flex-col gap-1">
           <label className="text-xs text-text/60 font-medium">{label}</label>
           {option.description && (
-            <span className="text-xs text-text/40">
+            <span className="text-xs text-text/50">
               {t(option.description)}
             </span>
           )}
@@ -107,7 +109,7 @@ const CloudOptionControl: React.FC<{
         <div className="flex flex-col gap-1">
           <label className="text-xs text-text/60 font-medium">{label}</label>
           {option.description && (
-            <span className="text-xs text-text/40">
+            <span className="text-xs text-text/50">
               {t(option.description)}
             </span>
           )}
@@ -130,15 +132,10 @@ const CloudOptionControl: React.FC<{
     case "Boolean": {
       return (
         <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={!!value}
-            onChange={(e) => onChange(e.target.checked)}
-            className="rounded border-muted/80 accent-[var(--color-accent)]"
-          />
+          <Checkbox checked={!!value} onChange={onChange} />
           <span className="text-xs text-text/60 font-medium">{label}</span>
           {option.description && (
-            <span className="text-xs text-text/40">
+            <span className="text-xs text-text/50">
               {t(option.description)}
             </span>
           )}
@@ -268,20 +265,22 @@ export const CloudProviderConfigCard: React.FC<
           <Badge variant="default">{t("modelSelector.active")}</Badge>
         )}
         {showVerifyHint && (
-          <span className="text-xs text-amber-400 font-medium animate-pulse">
+          <span className="text-xs text-warning font-medium animate-pulse">
             {t("settings.models.cloudProviders.verifyFirst")}
           </span>
         )}
         <button
           type="button"
-          className="ml-auto p-1 rounded text-text/40 hover:text-text/70 hover:bg-muted/20 transition-colors"
+          aria-expanded={expanded}
+          aria-label={expanded ? "Collapse" : "Expand"}
+          className="ml-auto p-1.5 rounded text-text/40 hover:text-text/70 hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring transition-colors"
           onClick={(e) => {
             e.stopPropagation();
             setExpanded((v) => !v);
           }}
         >
           <CaretDown
-            className={`w-4 h-4 transition-transform ${expanded ? "rotate-180" : ""}`}
+            className={`w-4 h-4 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
           />
         </button>
       </div>
@@ -297,7 +296,12 @@ export const CloudProviderConfigCard: React.FC<
 
       {/* Inline config fields */}
       {expanded && (
-        <>
+        <motion.div
+          initial={{ opacity: 0, y: -4 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+          className="flex flex-col gap-2"
+        >
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation wrapper for input focus */}
           <div
             className="flex flex-wrap gap-2 items-center w-fit"
@@ -332,7 +336,7 @@ export const CloudProviderConfigCard: React.FC<
                 disabled={
                   isVerifying || !localApiKey.trim() || !localModel.trim()
                 }
-                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-md bg-accent/10 text-accent hover:bg-accent/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-md bg-accent/10 text-accent hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
                 onClick={async () => {
                   setVerifyError(null);
                   try {
@@ -362,13 +366,13 @@ export const CloudProviderConfigCard: React.FC<
               </button>
             )}
             {verifyError && (
-              <span className="text-xs text-red-400">{verifyError}</span>
+              <span className="text-xs text-error">{verifyError}</span>
             )}
             {provider.backend.type === "Cloud" &&
               provider.backend.console_url && (
                 <button
                   type="button"
-                  className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-md text-text/60 hover:text-text hover:bg-muted/20 transition-colors"
+                  className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-md text-text/60 hover:text-text hover:bg-muted/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring transition-colors"
                   onClick={() => {
                     if (
                       provider.backend.type === "Cloud" &&
@@ -389,17 +393,15 @@ export const CloudProviderConfigCard: React.FC<
             // biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation wrapper
             <div onClick={stopPropagation}>
               <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={realtimeEnabled}
-                  onChange={(e) => onRealtimeChange(e.target.checked)}
-                  className="rounded border-muted/80 accent-[var(--color-accent)]"
+                  onChange={onRealtimeChange}
                 />
                 <span className="text-xs text-text/60 font-medium">
                   {t("settings.models.cloudProviders.realtimeTranscription")}
                 </span>
               </label>
-              <p className="text-[10px] text-text/40 mt-0.5 ml-6">
+              <p className="text-[11px] text-text/50 mt-0.5 ml-6">
                 {t("settings.models.cloudProviders.realtimeDescription")}
               </p>
             </div>
@@ -437,7 +439,7 @@ export const CloudProviderConfigCard: React.FC<
                 ))}
               </div>
             )}
-        </>
+        </motion.div>
       )}
 
       {/* Language/translation tags */}

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -22,7 +22,7 @@ export const ModelsSettings: React.FC = () => {
   }
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <div className="mb-4">
         <h1 className="text-xl font-semibold mb-2">
           {t("settings.models.title")}

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -444,7 +444,7 @@ export const PostProcessingSettings: React.FC = () => {
     : null;
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.postProcessing")}</h1>
       <SettingsGroup title={t("settings.postProcessing.api.title")}>
         <PostProcessingSettingsApi />

--- a/src/components/settings/shortcuts/ShortcutsSettings.tsx
+++ b/src/components/settings/shortcuts/ShortcutsSettings.tsx
@@ -7,7 +7,7 @@ import { ShortcutBindingsCard } from "../general/ShortcutBindingsCard";
 export const ShortcutsSettings: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.shortcuts")}</h1>
       <ShortcutBindingsCard />
       <SettingsGroup title={t("settings.general.title")}>

--- a/src/components/settings/stats/StatsSettings.tsx
+++ b/src/components/settings/stats/StatsSettings.tsx
@@ -312,7 +312,7 @@ export const StatsSettings: React.FC = () => {
   }
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-6">
+    <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.stats")}</h1>
       <div className="space-y-3">
         <div className="px-3">

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Check } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+interface CheckboxProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> {
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, checked = false, onChange, disabled, ...props }, ref) => {
+    return (
+      <span
+        className={cn(
+          "group relative inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border transition-colors",
+          checked
+            ? "border-primary bg-primary"
+            : "border-muted/60 bg-transparent",
+          disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+          "has-[:focus-visible]:ring-1 has-[:focus-visible]:ring-ring has-[:focus-visible]:ring-offset-1",
+          className,
+        )}
+      >
+        <input
+          type="checkbox"
+          ref={ref}
+          checked={checked}
+          onChange={(e) => onChange?.(e.target.checked)}
+          disabled={disabled}
+          className="sr-only"
+          {...props}
+        />
+        {checked && (
+          <Check weight="bold" className="h-3 w-3 text-white" />
+        )}
+      </span>
+    );
+  },
+);
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox };
+export type { CheckboxProps };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -29,4 +29,5 @@ export {
   CardContent,
 } from "./Card";
 export { Switch } from "./Switch";
+export { Checkbox } from "./Checkbox";
 export { Label } from "./Label";


### PR DESCRIPTION
## Summary
- Add a reusable `Checkbox` UI component with styled visuals, replacing raw `<input type="checkbox">` across settings
- Increase settings page section spacing (`space-y-6` → `space-y-8`) for better visual breathing room
- Improve `CloudProviderConfigCard` accessibility: `aria-expanded`/`aria-label` on toggle, `focus-visible` rings on interactive elements, semantic color tokens (`text-warning`, `text-error`), and expand animation via `motion.div`

## Test plan
- [ ] Verify checkboxes render and toggle correctly in Export/Import settings
- [ ] Verify checkboxes in CloudProviderConfigCard (boolean options, realtime toggle)
- [ ] Confirm settings pages have visually increased spacing between sections
- [ ] Check keyboard navigation (Tab/Space) on the new Checkbox and expand button