### PR TITLE
refactor(ui): simplify NumberInput to native input

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -106,12 +106,12 @@ body {
 }
 
 :root[data-theme="light"] {
+  color-scheme: light;
   background-color: rgba(253, 251, 249, 0.92);
 }
 
 @layer base {
   :root[data-theme="light"] {
-    color-scheme: light;
     --color-text: #1c1714;
     --color-background: #fdfbf9;
     --color-surface: #f5f3f1;

--- a/src/components/settings/RecordingRetentionPeriod.tsx
+++ b/src/components/settings/RecordingRetentionPeriod.tsx
@@ -27,8 +27,8 @@ export const RecordingRetentionPeriodSelector: React.FC<RecordingRetentionPeriod
       );
     };
 
-    const handleLimitChange = (value: number) => {
-      updateSetting("history_limit", value);
+    const handleLimitChange = (value: number | undefined) => {
+      if (value !== undefined) updateSetting("history_limit", value);
     };
 
     const retentionOptions = [

--- a/src/components/settings/models/CloudProviderConfigCard.tsx
+++ b/src/components/settings/models/CloudProviderConfigCard.tsx
@@ -12,6 +12,7 @@ import {
 import { motion } from "motion/react";
 import { ApiKeyField } from "@/components/settings/PostProcessingSettingsApi/ApiKeyField";
 import { Input } from "@/components/ui/Input";
+import { NumberInput } from "@/components/ui/NumberInput";
 import Badge from "@/components/ui/Badge";
 import { Dropdown } from "@/components/ui/Dropdown";
 import { MultiSelectDropdown } from "@/components/ui/MultiSelectDropdown";
@@ -113,18 +114,13 @@ const CloudOptionControl: React.FC<{
               {t(option.description)}
             </span>
           )}
-          <Input
-            type="number"
-            value={value !== undefined && value !== null ? String(value) : ""}
+          <NumberInput
+            value={typeof value === "number" ? value : undefined}
             placeholder={String(min)}
-            onChange={(e) =>
-              onChange(e.target.value ? Number(e.target.value) : undefined)
-            }
+            onChange={onChange}
             min={min}
             max={max}
             step={step}
-            variant="compact"
-            className="max-w-[70px]"
           />
         </div>
       );

--- a/src/components/ui/NumberInput.tsx
+++ b/src/components/ui/NumberInput.tsx
@@ -1,73 +1,46 @@
 import React from "react";
-import { Minus, Plus } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import { inputVariants } from "./Input";
 
 interface NumberInputProps {
-  value: number;
-  onChange: (value: number) => void;
+  value?: number;
+  onChange: (value: number | undefined) => void;
   min?: number;
   max?: number;
   step?: number;
   disabled?: boolean;
+  placeholder?: string;
   className?: string;
 }
 
-const stepBtnCn = (side: "l" | "r") =>
-  cn(
-    "flex items-center justify-center h-7 w-7 text-muted-foreground",
-    "hover:text-text hover:bg-glass-highlight transition-colors",
-    "disabled:opacity-40 disabled:pointer-events-none cursor-pointer",
-    side === "l" ? "rounded-l-md" : "rounded-r-md",
-  );
+const compactClasses = inputVariants({ variant: "compact" });
 
-const NumberInput = React.forwardRef<HTMLDivElement, NumberInputProps>(
-  (
-    { value, onChange, min = 0, max = Infinity, step = 1, disabled, className },
-    ref,
-  ) => {
-    const clamp = (v: number) => Math.min(max, Math.max(min, v));
-
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const parsed = parseInt(e.target.value, 10);
-      if (!isNaN(parsed)) {
-        onChange(clamp(parsed));
-      }
-    };
-
+const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ value, onChange, min, max, className, ...props }, ref) => {
     return (
-      <div
+      <input
         ref={ref}
-        className={cn(
-          "inline-flex items-center rounded-md border border-glass-border bg-glass-bg shadow-sm",
-          disabled && "opacity-50 pointer-events-none",
-          className,
-        )}
-      >
-        <button
-          type="button"
-          onClick={() => onChange(clamp(value - step))}
-          disabled={disabled || value <= min}
-          className={stepBtnCn("l")}
-        >
-          <Minus size={12} weight="bold" />
-        </button>
-        <input
-          type="text"
-          inputMode="numeric"
-          value={value}
-          onChange={handleInputChange}
-          disabled={disabled}
-          className="h-7 w-10 text-center text-sm bg-transparent border-x border-glass-border text-text focus:outline-none"
-        />
-        <button
-          type="button"
-          onClick={() => onChange(clamp(value + step))}
-          disabled={disabled || value >= max}
-          className={stepBtnCn("r")}
-        >
-          <Plus size={12} weight="bold" />
-        </button>
-      </div>
+        type="number"
+        value={value ?? ""}
+        onChange={(e) => {
+          if (!e.target.value) {
+            onChange(undefined);
+            return;
+          }
+          const parsed = parseFloat(e.target.value);
+          if (!isNaN(parsed)) {
+            const clamped =
+              min !== undefined || max !== undefined
+                ? Math.min(max ?? Infinity, Math.max(min ?? -Infinity, parsed))
+                : parsed;
+            onChange(clamped);
+          }
+        }}
+        min={min}
+        max={max}
+        className={cn(compactClasses, "max-w-[70px]", className)}
+        {...props}
+      />
     );
   },
 );


### PR DESCRIPTION
## Summary
- Replace custom stepper `NumberInput` (with +/- buttons) with a native `<input type="number">` using existing `inputVariants` styles
- Update `CloudProviderConfigCard` to use `NumberInput` directly instead of a generic `Input` with manual number conversion
- Move `color-scheme: light` declaration outside `@layer base` so it applies at the correct specificity
- Handle `undefined` value from `NumberInput` in `RecordingRetentionPeriod`

## Test plan
- [ ] Verify number inputs in cloud provider config cards accept and clamp values correctly
- [ ] Verify recording retention period number input works as expected
- [ ] Verify light theme renders correctly with color-scheme fix