### PR TITLE
refactor: move animations into settings pages, simplify motion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,12 +22,6 @@ import { pageVariants, pageTransition } from "@/lib/motion";
 
 type OnboardingStep = "accessibility" | "done";
 
-const renderSettingsContent = (section: SidebarSection) => {
-  const ActiveComponent =
-    SECTIONS_CONFIG[section]?.component || SECTIONS_CONFIG.general.component;
-  return <ActiveComponent />;
-};
-
 function App() {
   const { i18n } = useTranslation();
   const [onboardingStep, setOnboardingStep] = useState<OnboardingStep | null>(
@@ -35,6 +29,9 @@ function App() {
   );
   const [currentSection, setCurrentSection] =
     useState<SidebarSection>("general");
+  const ActiveComponent =
+    SECTIONS_CONFIG[currentSection]?.component ||
+    SECTIONS_CONFIG.general.component;
   const {
     settings,
     updateSetting,
@@ -197,19 +194,9 @@ function App() {
                 <div className="flex-1 overflow-y-auto overscroll-contain">
                   <div className="flex flex-col items-center p-5 gap-5">
                     <AccessibilityPermissions />
-                    <AnimatePresence mode="wait">
-                      <motion.div
-                        key={currentSection}
-                        variants={pageVariants}
-                        initial="initial"
-                        animate="animate"
-                        exit="exit"
-                        transition={pageTransition}
-                        className="w-full flex flex-col items-center"
-                      >
-                        {renderSettingsContent(currentSection)}
-                      </motion.div>
-                    </AnimatePresence>
+                    <div className="w-full flex flex-col items-center">
+                      <ActiveComponent />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { motion, AnimatePresence } from "motion/react";
+import { motion } from "motion/react";
 import { toast } from "sonner";
+import { staggerContainer, staggerItem } from "@/lib/motion";
 import { AudioPlayer } from "../../ui/AudioPlayer";
 import { Button } from "../../ui/Button";
 import {
@@ -144,101 +145,77 @@ export const HistorySettings: React.FC = () => {
     />
   );
 
+  let content;
   if (loading) {
-    return (
-      <div className="max-w-3xl w-full mx-auto space-y-8">
-        <h1 className="sr-only">{t("sidebar.history")}</h1>
-        {retentionSection}
-        <div className="space-y-1.5">
-          <div className="px-3 flex items-center justify-between">
-            <div>
-              <h2 className="text-xs font-medium text-muted uppercase tracking-wide">
-                {t("settings.history.title")}
-              </h2>
-            </div>
-            <OpenRecordingsButton
-              onClick={openRecordingsFolder}
-              label={t("settings.history.openFolder")}
-            />
-          </div>
-          <div className="bg-background-translucent border border-glass-border rounded overflow-visible">
-            <div className="px-3 py-8 flex flex-col items-center gap-3">
-              <div className="w-5 h-5 border-2 border-muted/40 border-t-accent rounded-full animate-spin" />
-              <p className="text-sm text-muted">
-                {t("settings.history.loading")}
-              </p>
-            </div>
-          </div>
+    content = (
+      <div className="bg-background-translucent border border-glass-border rounded overflow-visible">
+        <div className="px-3 py-8 flex flex-col items-center gap-3">
+          <div className="w-5 h-5 border-2 border-muted/40 border-t-accent rounded-full animate-spin" />
+          <p className="text-sm text-muted">
+            {t("settings.history.loading")}
+          </p>
         </div>
       </div>
     );
-  }
-
-  if (historyEntries.length === 0) {
-    return (
-      <div className="max-w-3xl w-full mx-auto space-y-8">
-        <h1 className="sr-only">{t("sidebar.history")}</h1>
-        {retentionSection}
-        <div className="space-y-1.5">
-          <div className="px-3 flex items-center justify-between">
-            <div>
-              <h2 className="text-xs font-medium text-muted uppercase tracking-wide">
-                {t("settings.history.title")}
-              </h2>
-            </div>
-            <OpenRecordingsButton
-              onClick={openRecordingsFolder}
-              label={t("settings.history.openFolder")}
-            />
+  } else if (historyEntries.length === 0) {
+    content = (
+      <div className="bg-background-translucent border border-glass-border rounded overflow-visible">
+        <div className="px-3 py-10 flex flex-col items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-muted/10 flex items-center justify-center">
+            <Microphone className="w-5 h-5 text-muted/60" />
           </div>
-          <div className="bg-background-translucent border border-glass-border rounded overflow-visible">
-            <div className="px-3 py-10 flex flex-col items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-muted/10 flex items-center justify-center">
-                <Microphone className="w-5 h-5 text-muted/60" />
-              </div>
-              <p className="text-sm text-muted text-center">
-                {t("settings.history.empty")}
-              </p>
-            </div>
-          </div>
+          <p className="text-sm text-muted text-center">
+            {t("settings.history.empty")}
+          </p>
         </div>
+      </div>
+    );
+  } else {
+    content = (
+      <div className="flex flex-col gap-2">
+        {historyEntries.map((entry) => (
+          <HistoryEntryComponent
+            key={entry.id}
+            entry={entry}
+            onToggleSaved={() => toggleSaved(entry.id)}
+            onCopyText={(text) => copyToClipboard(text)}
+            getAudioUrl={getAudioUrl}
+            deleteAudio={deleteAudioEntry}
+          />
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-8">
+    <motion.div
+      className="max-w-3xl w-full mx-auto space-y-8"
+      variants={staggerContainer}
+      initial="initial"
+      animate="animate"
+    >
       <h1 className="sr-only">{t("sidebar.history")}</h1>
-      {retentionSection}
-      <div className="space-y-1.5">
+      <motion.div variants={staggerItem}>{retentionSection}</motion.div>
+      <motion.div className="space-y-1.5" variants={staggerItem}>
         <div className="px-3 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <h2 className="text-xs font-medium text-muted uppercase tracking-wide">
               {t("settings.history.title")}
             </h2>
-            <span className="text-[10px] text-muted/60 tabular-nums">
-              {historyEntries.length}
-            </span>
+            {!loading && historyEntries.length > 0 && (
+              <span className="text-[10px] text-muted/60 tabular-nums">
+                {historyEntries.length}
+              </span>
+            )}
           </div>
           <OpenRecordingsButton
             onClick={openRecordingsFolder}
             label={t("settings.history.openFolder")}
           />
         </div>
-        <div className="flex flex-col gap-2">
-          {historyEntries.map((entry) => (
-            <HistoryEntryComponent
-              key={entry.id}
-              entry={entry}
-              onToggleSaved={() => toggleSaved(entry.id)}
-              onCopyText={(text) => copyToClipboard(text)}
-              getAudioUrl={getAudioUrl}
-              deleteAudio={deleteAudioEntry}
-            />
-          ))}
-        </div>
-      </div>
-    </div>
+        {content}
+      </motion.div>
+    </motion.div>
   );
 };
 

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { motion } from "motion/react";
 import { useModelStore } from "@/stores/modelStore";
+import { staggerContainer, staggerItem } from "@/lib/motion";
 import { MyModelsTab } from "./MyModelsTab";
 import { LibraryTab } from "./LibraryTab";
 
@@ -11,59 +13,66 @@ export const ModelsSettings: React.FC = () => {
   const [activeTab, setActiveTab] = useState<Tab>("myModels");
   const { loading } = useModelStore();
 
-  if (loading) {
-    return (
-      <div className="max-w-3xl w-full mx-auto">
-        <div className="flex items-center justify-center py-16">
-          <div className="w-8 h-8 border-2 border-accent border-t-transparent rounded-full animate-spin" />
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="max-w-3xl w-full mx-auto space-y-8">
-      <div className="mb-4">
+    <motion.div
+      className="max-w-3xl w-full mx-auto space-y-8"
+      variants={staggerContainer}
+      initial="initial"
+      animate="animate"
+    >
+      <motion.div className="mb-4" variants={staggerItem}>
         <h1 className="text-xl font-semibold mb-2">
           {t("settings.models.title")}
         </h1>
         <p className="text-sm text-muted-foreground">
           {t("settings.models.description")}
         </p>
-      </div>
+      </motion.div>
 
-      <div role="tablist" className="flex gap-1 border-b border-muted/20 mb-4">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={activeTab === "myModels"}
-          onClick={() => setActiveTab("myModels")}
-          className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-            activeTab === "myModels"
-              ? "border-accent text-accent"
-              : "border-transparent text-text/50 hover:text-text/80"
-          }`}
-        >
-          {t("settings.models.tabs.myModels")}
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={activeTab === "library"}
-          onClick={() => setActiveTab("library")}
-          className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-            activeTab === "library"
-              ? "border-accent text-accent"
-              : "border-transparent text-text/50 hover:text-text/80"
-          }`}
-        >
-          {t("settings.models.tabs.library")}
-        </button>
-      </div>
+      <motion.div variants={staggerItem}>
+        <div role="tablist" className="flex gap-1 border-b border-muted/20 mb-4">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "myModels"}
+            onClick={() => setActiveTab("myModels")}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              activeTab === "myModels"
+                ? "border-accent text-accent"
+                : "border-transparent text-text/50 hover:text-text/80"
+            }`}
+          >
+            {t("settings.models.tabs.myModels")}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === "library"}
+            onClick={() => setActiveTab("library")}
+            className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              activeTab === "library"
+                ? "border-accent text-accent"
+                : "border-transparent text-text/50 hover:text-text/80"
+            }`}
+          >
+            {t("settings.models.tabs.library")}
+          </button>
+        </div>
 
-      <div role="tabpanel">
-        {activeTab === "myModels" ? <MyModelsTab /> : <LibraryTab />}
-      </div>
-    </div>
+        <div role="tabpanel">
+          {loading ? (
+            <div className="bg-background-translucent border border-glass-border rounded">
+              <div className="px-3 py-8 flex flex-col items-center gap-3">
+                <div className="w-5 h-5 border-2 border-muted/40 border-t-accent rounded-full animate-spin" />
+              </div>
+            </div>
+          ) : activeTab === "myModels" ? (
+            <MyModelsTab />
+          ) : (
+            <LibraryTab />
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
   );
 };

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -13,13 +13,13 @@ export const hoverLift = { y: -3, transition: spring.gentle };
 
 // ── Page / section transition variants ─────────────────────────────
 export const pageVariants: Variants = {
-  initial: { opacity: 0, y: 10, filter: "blur(3px)" },
-  animate: { opacity: 1, y: 0, filter: "blur(0px)" },
-  exit: { opacity: 0, y: -5, filter: "blur(3px)" },
+  initial: { opacity: 0, y: 6 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -4 },
 };
 
 export const pageTransition: Transition = {
-  duration: 0.3,
+  duration: 0.15,
   ease: [0.16, 1, 0.3, 1], // ease-out-expo
 };
 


### PR DESCRIPTION
## Summary
- Move page transition animations from App.tsx AnimatePresence wrapper into individual settings pages (HistorySettings, ModelsSettings) using stagger container/item variants
- Remove GPU-expensive blur filter from page transitions and reduce duration (0.3s → 0.15s) for snappier feel
- Consolidate HistorySettings from 3 early returns into single return with shared layout structure
- Remove unused AnimatePresence import and simplify IIFE to direct component resolution in App.tsx

## Test plan
- [ ] Verify settings page transitions feel smooth when switching between sidebar sections
- [ ] Verify History and Models pages animate in with stagger effect on mount
- [ ] Verify loading states display correctly in History and Models pages
- [ ] Verify empty state displays correctly in History page