### PR TITLE
feat(history): cursor-based paginated history with infinite scroll

### DIFF
--- a/src-tauri/src/commands/history.rs
+++ b/src-tauri/src/commands/history.rs
@@ -1,4 +1,4 @@
-use crate::managers::history::{DailySpeakingStats, HistoryEntry, HistoryManager};
+use crate::managers::history::{DailySpeakingStats, HistoryEntry, HistoryManager, HistoryPage};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
@@ -11,6 +11,19 @@ pub async fn get_history_entries(
     history_manager
         .get_history_entries()
         .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_history_entries_page(
+    _app: AppHandle,
+    history_manager: State<'_, Arc<HistoryManager>>,
+    limit: i64,
+    cursor: Option<i64>,
+) -> Result<HistoryPage, String> {
+    history_manager
+        .get_history_entries_page(limit, cursor)
         .map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -374,6 +374,7 @@ pub fn run(cli_args: CliArgs) {
         commands::transcription::get_model_load_status,
         commands::transcription::unload_model_manually,
         commands::history::get_history_entries,
+        commands::history::get_history_entries_page,
         commands::history::toggle_history_entry_saved,
         commands::history::get_audio_file_path,
         commands::history::delete_history_entry,

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -54,12 +54,31 @@ pub struct HistoryEntry {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
+pub struct HistoryPage {
+    pub entries: Vec<HistoryEntry>,
+    pub total_count: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
 pub struct DailySpeakingStats {
     pub date: String,
     pub total_word_count: i64,
     pub total_duration_ms: i64,
     pub transcription_count: i64,
     pub avg_wpm: f64,
+}
+
+fn row_to_entry(row: &rusqlite::Row) -> rusqlite::Result<HistoryEntry> {
+    Ok(HistoryEntry {
+        id: row.get("id")?,
+        file_name: row.get("file_name")?,
+        timestamp: row.get("timestamp")?,
+        saved: row.get("saved")?,
+        title: row.get("title")?,
+        transcription_text: row.get("transcription_text")?,
+        post_processed_text: row.get("post_processed_text")?,
+        post_process_prompt: row.get("post_process_prompt")?,
+    })
 }
 
 pub struct HistoryManager {
@@ -217,7 +236,8 @@ impl HistoryManager {
             "INSERT INTO transcription_history (file_name, timestamp, saved, title, transcription_text, post_processed_text, post_process_prompt) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             params![file_name, timestamp, false, title, transcription_text, post_processed_text, post_process_prompt],
         )?;
-        debug!("Saved transcription to database");
+        let new_id = conn.last_insert_rowid();
+        debug!("Saved transcription to database with id: {}", new_id);
 
         let today = Local::now().format("%Y-%m-%d").to_string();
         conn.execute(
@@ -234,9 +254,19 @@ impl HistoryManager {
         // Clean up old entries
         self.cleanup_old_entries()?;
 
-        // Emit history updated event
-        if let Err(e) = self.app_handle.emit("history-updated", ()) {
-            error!("Failed to emit history-updated event: {}", e);
+        // Emit the new entry so the frontend can prepend it without a full reload
+        let new_entry = HistoryEntry {
+            id: new_id,
+            file_name,
+            timestamp,
+            saved: false,
+            title,
+            transcription_text,
+            post_processed_text,
+            post_process_prompt,
+        };
+        if let Err(e) = self.app_handle.emit("history-entry-added", &new_entry) {
+            error!("Failed to emit history-entry-added event: {}", e);
         }
 
         Ok(())
@@ -364,18 +394,7 @@ impl HistoryManager {
             "SELECT id, file_name, timestamp, saved, title, transcription_text, post_processed_text, post_process_prompt FROM transcription_history ORDER BY timestamp DESC"
         )?;
 
-        let rows = stmt.query_map([], |row| {
-            Ok(HistoryEntry {
-                id: row.get("id")?,
-                file_name: row.get("file_name")?,
-                timestamp: row.get("timestamp")?,
-                saved: row.get("saved")?,
-                title: row.get("title")?,
-                transcription_text: row.get("transcription_text")?,
-                post_processed_text: row.get("post_processed_text")?,
-                post_process_prompt: row.get("post_process_prompt")?,
-            })
-        })?;
+        let rows = stmt.query_map([], row_to_entry)?;
 
         let mut entries = Vec::new();
         for row in rows {
@@ -383,6 +402,40 @@ impl HistoryManager {
         }
 
         Ok(entries)
+    }
+
+    pub fn get_history_entries_page(&self, limit: i64, cursor: Option<i64>) -> Result<HistoryPage> {
+        let conn = self.get_connection()?;
+
+        let total_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM transcription_history",
+            [],
+            |row| row.get(0),
+        )?;
+
+        let (query, cursor_params): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = if cursor.is_some() {
+            (
+                "SELECT id, file_name, timestamp, saved, title, transcription_text, post_processed_text, post_process_prompt
+                 FROM transcription_history WHERE id < ?1 ORDER BY id DESC LIMIT ?2",
+                vec![Box::new(cursor.unwrap()), Box::new(limit)],
+            )
+        } else {
+            (
+                "SELECT id, file_name, timestamp, saved, title, transcription_text, post_processed_text, post_process_prompt
+                 FROM transcription_history ORDER BY id DESC LIMIT ?1",
+                vec![Box::new(limit)],
+            )
+        };
+
+        let mut stmt = conn.prepare(query)?;
+        let entries = stmt
+            .query_map(rusqlite::params_from_iter(cursor_params), row_to_entry)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(HistoryPage {
+            entries,
+            total_count,
+        })
     }
 
     pub fn get_latest_entry(&self) -> Result<Option<HistoryEntry>> {
@@ -398,20 +451,7 @@ impl HistoryManager {
              LIMIT 1",
         )?;
 
-        let entry = stmt
-            .query_row([], |row| {
-                Ok(HistoryEntry {
-                    id: row.get("id")?,
-                    file_name: row.get("file_name")?,
-                    timestamp: row.get("timestamp")?,
-                    saved: row.get("saved")?,
-                    title: row.get("title")?,
-                    transcription_text: row.get("transcription_text")?,
-                    post_processed_text: row.get("post_processed_text")?,
-                    post_process_prompt: row.get("post_process_prompt")?,
-                })
-            })
-            .optional()?;
+        let entry = stmt.query_row([], row_to_entry).optional()?;
 
         Ok(entry)
     }
@@ -434,11 +474,6 @@ impl HistoryManager {
         )?;
 
         debug!("Toggled saved status for entry {}: {}", id, new_saved);
-
-        // Emit history updated event
-        if let Err(e) = self.app_handle.emit("history-updated", ()) {
-            error!("Failed to emit history-updated event: {}", e);
-        }
 
         Ok(())
     }
@@ -534,20 +569,7 @@ impl HistoryManager {
              FROM transcription_history WHERE id = ?1",
         )?;
 
-        let entry = stmt
-            .query_row([id], |row| {
-                Ok(HistoryEntry {
-                    id: row.get("id")?,
-                    file_name: row.get("file_name")?,
-                    timestamp: row.get("timestamp")?,
-                    saved: row.get("saved")?,
-                    title: row.get("title")?,
-                    transcription_text: row.get("transcription_text")?,
-                    post_processed_text: row.get("post_processed_text")?,
-                    post_process_prompt: row.get("post_process_prompt")?,
-                })
-            })
-            .optional()?;
+        let entry = stmt.query_row([id], row_to_entry).optional()?;
 
         Ok(entry)
     }
@@ -574,11 +596,6 @@ impl HistoryManager {
         )?;
 
         debug!("Deleted history entry with id: {}", id);
-
-        // Emit history updated event
-        if let Err(e) = self.app_handle.emit("history-updated", ()) {
-            error!("Failed to emit history-updated event: {}", e);
-        }
 
         Ok(())
     }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -759,6 +759,14 @@ async getHistoryEntries() : Promise<Result<HistoryEntry[], string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async getHistoryEntriesPage(limit: number, cursor: number | null) : Promise<Result<HistoryPage, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_history_entries_page", { limit, cursor }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async toggleHistoryEntrySaved(id: number) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("toggle_history_entry_saved", { id }) };
@@ -877,6 +885,7 @@ export type CustomSounds = { start: boolean; stop: boolean }
 export type DailySpeakingStats = { date: string; total_word_count: number; total_duration_ms: number; transcription_count: number; avg_wpm: number }
 export type EngineType = "Whisper" | "Parakeet" | "Moonshine" | "MoonshineStreaming" | "SenseVoice"
 export type HistoryEntry = { id: number; file_name: string; timestamp: number; saved: boolean; title: string; transcription_text: string; post_processed_text: string | null; post_process_prompt: string | null }
+export type HistoryPage = { entries: HistoryEntry[]; total_count: number }
 /**
  * Result of changing keyboard implementation
  */

--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
 import { toast } from "sonner";
@@ -22,6 +22,8 @@ import { formatRelativeTime, formatDateTime } from "@/utils/dateFormat";
 import { useOsType } from "@/hooks/useOsType";
 import { SimpleTooltip } from "../../ui/Tooltip";
 import { RecordingRetentionPeriodSelector } from "../RecordingRetentionPeriod";
+
+const PAGE_SIZE = 50;
 
 interface OpenRecordingsButtonProps {
   onClick: () => void;
@@ -48,32 +50,48 @@ export const HistorySettings: React.FC = () => {
   const { t } = useTranslation();
   const osType = useOsType();
   const [historyEntries, setHistoryEntries] = useState<HistoryEntry[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
-  const loadHistoryEntries = useCallback(async () => {
-    try {
-      const result = await commands.getHistoryEntries();
+  const hasMore = historyEntries.length < totalCount;
+
+  const loadPage = useCallback(
+    async (cursor: number | null, replace: boolean) => {
+      const result = await commands.getHistoryEntriesPage(PAGE_SIZE, cursor);
       if (result.status === "ok") {
-        setHistoryEntries(result.data);
+        const { entries, total_count } = result.data;
+        if (replace) {
+          setHistoryEntries(entries);
+        } else {
+          setHistoryEntries((prev) => [...prev, ...entries]);
+        }
+        setTotalCount(total_count);
       }
-    } catch (error) {
-      console.error("Failed to load history entries:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+    },
+    [],
+  );
 
+  // Initial load
   useEffect(() => {
-    loadHistoryEntries();
+    loadPage(null, true).finally(() => setLoading(false));
+  }, [loadPage]);
 
+  // Listen for new transcriptions from the backend
+  useEffect(() => {
     const setupListener = async () => {
-      const unlisten = await listen("history-updated", () => {
-        loadHistoryEntries();
-      });
+      const unlisten = await listen<HistoryEntry>(
+        "history-entry-added",
+        (event) => {
+          setHistoryEntries((prev) => [event.payload, ...prev]);
+          setTotalCount((prev) => prev + 1);
+        },
+      );
       return unlisten;
     };
 
-    let unlistenPromise = setupListener();
+    const unlistenPromise = setupListener();
 
     return () => {
       unlistenPromise.then((unlisten) => {
@@ -82,23 +100,61 @@ export const HistorySettings: React.FC = () => {
         }
       });
     };
-  }, [loadHistoryEntries]);
+  }, []);
 
-  const toggleSaved = async (id: number) => {
+  // Infinite scroll via IntersectionObserver.
+  // Use a ref for mutable state so the observer is created once and doesn't
+  // churn on every page load or real-time event.
+  const scrollStateRef = useRef({ hasMore, loadingMore, lastId: null as number | null });
+  scrollStateRef.current = {
+    hasMore,
+    loadingMore,
+    lastId: historyEntries[historyEntries.length - 1]?.id ?? null,
+  };
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        const { hasMore, loadingMore, lastId } = scrollStateRef.current;
+        if (entry.isIntersecting && hasMore && !loadingMore) {
+          setLoadingMore(true);
+          loadPage(lastId, false).finally(() =>
+            setLoadingMore(false),
+          );
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadPage]);
+
+  const toggleSaved = useCallback(async (id: number) => {
+    setHistoryEntries((prev) =>
+      prev.map((e) => (e.id === id ? { ...e, saved: !e.saved } : e)),
+    );
     try {
       await commands.toggleHistoryEntrySaved(id);
     } catch (error) {
       console.error("Failed to toggle saved status:", error);
+      // Revert on error
+      setHistoryEntries((prev) =>
+        prev.map((e) => (e.id === id ? { ...e, saved: !e.saved } : e)),
+      );
     }
-  };
+  }, []);
 
-  const copyToClipboard = async (text: string) => {
+  const copyToClipboard = useCallback(async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
     } catch (error) {
       console.error("Failed to copy to clipboard:", error);
     }
-  };
+  }, []);
 
   const getAudioUrl = useCallback(
     async (fileName: string) => {
@@ -121,14 +177,17 @@ export const HistorySettings: React.FC = () => {
     [osType],
   );
 
-  const deleteAudioEntry = async (id: number) => {
+  const deleteEntry = useCallback(async (id: number) => {
+    setHistoryEntries((prev) => prev.filter((e) => e.id !== id));
+    setTotalCount((prev) => prev - 1);
     try {
       await commands.deleteHistoryEntry(id);
     } catch (error) {
-      console.error("Failed to delete audio entry:", error);
-      throw error;
+      console.error("Failed to delete entry:", error);
+      // Reload on error to restore correct state
+      loadPage(null, true);
     }
-  };
+  }, [loadPage]);
 
   const openRecordingsFolder = async () => {
     try {
@@ -177,12 +236,17 @@ export const HistorySettings: React.FC = () => {
           <HistoryEntryComponent
             key={entry.id}
             entry={entry}
-            onToggleSaved={() => toggleSaved(entry.id)}
-            onCopyText={(text) => copyToClipboard(text)}
+            onToggleSaved={toggleSaved}
+            onCopy={copyToClipboard}
             getAudioUrl={getAudioUrl}
-            deleteAudio={deleteAudioEntry}
+            onDelete={deleteEntry}
           />
         ))}
+        <div ref={sentinelRef} className="py-4 flex justify-center">
+          {loadingMore && (
+            <div className="w-5 h-5 border-2 border-muted/40 border-t-accent rounded-full animate-spin" />
+          )}
+        </div>
       </div>
     );
   }
@@ -202,9 +266,9 @@ export const HistorySettings: React.FC = () => {
             <h2 className="text-xs font-medium text-muted uppercase tracking-wide">
               {t("settings.history.title")}
             </h2>
-            {!loading && historyEntries.length > 0 && (
+            {!loading && totalCount > 0 && (
               <span className="text-[10px] text-muted/60 tabular-nums">
-                {historyEntries.length}
+                {totalCount}
               </span>
             )}
           </div>
@@ -221,129 +285,122 @@ export const HistorySettings: React.FC = () => {
 
 interface HistoryEntryProps {
   entry: HistoryEntry;
-  onToggleSaved: () => void;
-  onCopyText: (text: string) => void;
+  onToggleSaved: (id: number) => void;
+  onCopy: (text: string) => void;
   getAudioUrl: (fileName: string) => Promise<string | null>;
-  deleteAudio: (id: number) => Promise<void>;
+  onDelete: (id: number) => void;
 }
 
-const HistoryEntryComponent: React.FC<HistoryEntryProps> = ({
-  entry,
-  onToggleSaved,
-  onCopyText,
-  getAudioUrl,
-  deleteAudio,
-}) => {
-  const { t, i18n } = useTranslation();
-  const [showCopied, setShowCopied] = useState(false);
-  const [expanded, setExpanded] = useState(false);
+const HistoryEntryComponent: React.FC<HistoryEntryProps> = memo(
+  ({ entry, onToggleSaved, onCopy, getAudioUrl, onDelete }) => {
+    const { t, i18n } = useTranslation();
+    const [showCopied, setShowCopied] = useState(false);
+    const [expanded, setExpanded] = useState(false);
 
-  const handleLoadAudio = useCallback(
-    () => getAudioUrl(entry.file_name),
-    [getAudioUrl, entry.file_name],
-  );
+    const handleLoadAudio = useCallback(
+      () => getAudioUrl(entry.file_name),
+      [getAudioUrl, entry.file_name],
+    );
 
-  const displayText = entry.post_processed_text || entry.transcription_text;
-  const hasPostProcessed = !!entry.post_processed_text;
+    const displayText = entry.post_processed_text || entry.transcription_text;
+    const hasPostProcessed = !!entry.post_processed_text;
 
-  const handleCopyText = () => {
-    onCopyText(displayText);
-    setShowCopied(true);
-    setTimeout(() => setShowCopied(false), 2000);
-  };
+    const handleCopyText = () => {
+      onCopy(displayText);
+      setShowCopied(true);
+      setTimeout(() => setShowCopied(false), 2000);
+    };
 
-  const handleDeleteEntry = async () => {
-    try {
-      await deleteAudio(entry.id);
-    } catch (error) {
-      console.error("Failed to delete entry:", error);
-      toast.error(t("settings.history.deleteError"));
-    }
-  };
+    const handleDeleteEntry = () => {
+      onDelete(entry.id);
+    };
 
-  const relativeTime = formatRelativeTime(
-    String(entry.timestamp),
-    i18n.language,
-  );
-  const fullDate = formatDateTime(String(entry.timestamp), i18n.language);
+    const relativeTime = formatRelativeTime(
+      String(entry.timestamp),
+      i18n.language,
+    );
+    const fullDate = formatDateTime(String(entry.timestamp), i18n.language);
 
-  return (
-    <div className="group bg-background-translucent border border-glass-border rounded hover:border-glass-border-hover transition-colors px-3 py-2 flex flex-col gap-1.5">
-      {/* Header: timestamp + actions */}
-      <div className="flex justify-between items-center">
-        <SimpleTooltip content={fullDate}>
-          <span className="text-[11px] text-muted">{relativeTime}</span>
-        </SimpleTooltip>
-        <div className="flex items-center gap-0.5">
-          {/* Saved star - always visible when saved */}
-          {entry.saved && (
-            <SimpleTooltip content={t("settings.history.unsave")}>
-              <button
-                onClick={onToggleSaved}
-                className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-accent hover:text-accent/80 transition-colors cursor-pointer"
-              >
-                <Star size={14} weight="fill" />
-              </button>
-            </SimpleTooltip>
-          )}
-          {/* Other actions - visible on hover */}
-          <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-            <SimpleTooltip content={t("settings.history.copyToClipboard")}>
-              <button
-                onClick={handleCopyText}
-                className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-text/50 hover:text-accent transition-colors cursor-pointer"
-              >
-                {showCopied ? <Check size={14} /> : <Copy size={14} />}
-              </button>
-            </SimpleTooltip>
-            {!entry.saved && (
-              <SimpleTooltip content={t("settings.history.save")}>
+    return (
+      <div className="group bg-background-translucent border border-glass-border rounded hover:border-glass-border-hover transition-colors px-3 py-2 flex flex-col gap-1.5">
+        {/* Header: timestamp + actions */}
+        <div className="flex justify-between items-center">
+          <SimpleTooltip content={fullDate}>
+            <span className="text-[11px] text-muted">{relativeTime}</span>
+          </SimpleTooltip>
+          <div className="flex items-center gap-0.5">
+            {/* Saved star - always visible when saved */}
+            {entry.saved && (
+              <SimpleTooltip content={t("settings.history.unsave")}>
                 <button
-                  onClick={onToggleSaved}
-                  className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-text/50 hover:text-accent transition-colors cursor-pointer"
+                  onClick={() => onToggleSaved(entry.id)}
+                  className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-accent hover:text-accent/80 transition-colors cursor-pointer"
                 >
-                  <Star size={14} weight="light" />
+                  <Star size={14} weight="fill" />
                 </button>
               </SimpleTooltip>
             )}
-            <SimpleTooltip content={t("settings.history.delete")}>
-              <button
-                onClick={handleDeleteEntry}
-                className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-text/50 hover:text-error transition-colors cursor-pointer"
-              >
-                <Trash size={14} />
-              </button>
-            </SimpleTooltip>
+            {/* Other actions - visible on hover */}
+            <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+              <SimpleTooltip content={t("settings.history.copyToClipboard")}>
+                <button
+                  onClick={handleCopyText}
+                  className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-text/50 hover:text-accent transition-colors cursor-pointer"
+                >
+                  {showCopied ? <Check size={14} /> : <Copy size={14} />}
+                </button>
+              </SimpleTooltip>
+              {!entry.saved && (
+                <SimpleTooltip content={t("settings.history.save")}>
+                  <button
+                    onClick={() => onToggleSaved(entry.id)}
+                    className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-text/50 hover:text-accent transition-colors cursor-pointer"
+                  >
+                    <Star size={14} weight="light" />
+                  </button>
+                </SimpleTooltip>
+              )}
+              <SimpleTooltip content={t("settings.history.delete")}>
+                <button
+                  onClick={handleDeleteEntry}
+                  className="p-2 min-w-[36px] min-h-[36px] flex items-center justify-center rounded text-text/50 hover:text-error transition-colors cursor-pointer"
+                >
+                  <Trash size={14} />
+                </button>
+              </SimpleTooltip>
+            </div>
           </div>
         </div>
+
+        {/* Text content */}
+        <p className="text-[13px] leading-snug text-text/90 select-text cursor-text">
+          {displayText}
+        </p>
+        {hasPostProcessed && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="flex items-center gap-1 text-[11px] text-muted/60 hover:text-muted transition-colors cursor-pointer"
+          >
+            <Sparkle size={10} />
+            <span>{expanded ? t("settings.history.hideOriginal") : t("settings.history.showOriginal")}</span>
+          </button>
+        )}
+        {hasPostProcessed && expanded && (
+          <motion.p
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+            className="text-[12px] leading-snug text-muted/70 select-text cursor-text border-l-2 border-glass-border pl-2"
+          >
+            {entry.transcription_text}
+          </motion.p>
+        )}
+
+        {/* Audio player */}
+        <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
       </div>
+    );
+  },
+);
 
-      {/* Text content */}
-      <p className="text-[13px] leading-snug text-text/90 select-text cursor-text">
-        {displayText}
-      </p>
-      {hasPostProcessed && (
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="flex items-center gap-1 text-[11px] text-muted/60 hover:text-muted transition-colors cursor-pointer"
-        >
-          <Sparkle size={10} />
-          <span>{expanded ? t("settings.history.hideOriginal") : t("settings.history.showOriginal")}</span>
-        </button>
-      )}
-      {hasPostProcessed && expanded && (
-        <motion.p
-          initial={{ opacity: 0, y: -4 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
-          className="text-[12px] leading-snug text-muted/70 select-text cursor-text border-l-2 border-glass-border pl-2"
-        >
-          {entry.transcription_text}
-        </motion.p>
-      )}
-
-      {/* Audio player */}
-      <AudioPlayer onLoadRequest={handleLoadAudio} className="w-full" />
-    </div>
-  );
-};
+HistoryEntryComponent.displayName = "HistoryEntryComponent";


### PR DESCRIPTION
## Summary
- Replace offset-based pagination with cursor-based (`WHERE id < ?cursor`) to prevent duplicate/skipped entries when rows are added or deleted between page loads
- Add `get_history_entries_page` command with `limit` and `cursor: Option<i64>` params
- Emit incremental `history-entry-added` event with the new entry instead of a full-reload `history-updated` event
- Add infinite scroll via IntersectionObserver with a sentinel element
- Optimistic UI updates for toggle-saved (with revert on error) and delete (with full reload on error)
- Memoize `HistoryEntryComponent` with `React.memo` and stable `useCallback` refs
- Extract shared `row_to_entry` helper to DRY up 4 identical row-mapping blocks

## Test plan
- [ ] Open history settings, verify entries load correctly
- [ ] Scroll down past 50 entries and verify more pages load without duplicates
- [ ] Record a new transcription and verify it appears at the top without a full reload
- [ ] Toggle saved status and verify optimistic update (star appears/disappears immediately)
- [ ] Delete an entry and verify it disappears immediately
- [ ] Verify total count badge updates correctly on add/delete