### PR TITLE
refactor(app): simplify sidebar section nav shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,30 @@ function App() {
     };
   }, [settings?.debug_mode, updateSetting, refreshSettings]);
 
+  // Cmd+[ / Cmd+]: Navigate sidebar sections
+  useEffect(() => {
+    const handleSectionNav = (event: KeyboardEvent) => {
+      if (!event.metaKey) return;
+      if (event.key !== "[" && event.key !== "]") return;
+      event.preventDefault();
+
+      const delta = event.key === "[" ? -1 : 1;
+      setCurrentSection((prev) => {
+        const availableSections = (
+          Object.keys(SECTIONS_CONFIG) as SidebarSection[]
+        ).filter((id) => SECTIONS_CONFIG[id].enabled(settings));
+        const idx = availableSections.indexOf(prev);
+        if (idx === -1) return prev;
+        return availableSections[
+          (idx + delta + availableSections.length) % availableSections.length
+        ];
+      });
+    };
+
+    document.addEventListener("keydown", handleSectionNav);
+    return () => document.removeEventListener("keydown", handleSectionNav);
+  }, [settings?.debug_mode]);
+
   const checkOnboardingStatus = async () => {
     if (platform() === "macos") {
       try {


### PR DESCRIPTION
## Summary
- Use functional `setCurrentSection(prev => ...)` updater so `currentSection` is no longer needed in the effect dependency array — the listener no longer re-registers on every navigation
- Collapse the `if/else` prev/next branches into a single `delta` variable (`-1` or `+1`) with one modular-arithmetic expression
- Move `event.preventDefault()` before the updater for cleaner ordering

## Test plan
- [ ] Cmd+] navigates forward through sidebar sections
- [ ] Cmd+[ navigates backward through sidebar sections
- [ ] Navigation wraps around at both ends
- [ ] Debug section appears/disappears from navigation cycle when debug mode is toggled