### PR TITLE
refactor(overlay): polish recording overlay visuals and fix stale settings dep

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,7 +132,7 @@ function App() {
 
     document.addEventListener("keydown", handleSectionNav);
     return () => document.removeEventListener("keydown", handleSectionNav);
-  }, [settings?.debug_mode]);
+  }, [settings]);
 
   const checkOnboardingStatus = async () => {
     if (platform() === "macos") {

--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -23,22 +23,25 @@
 }
 
 .recording-overlay {
-  /* Intentionally always-dark: floating overlay renders on top of other apps */
-  /* width and height controlled by inline style */
+  /* Floating overlay — warm-tinted dark surface */
+  /* width, height, border-radius controlled by inline style */
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 6px;
-  background: rgb(0, 0, 0);
+  background: radial-gradient(
+    ellipse at 50% 0%,
+    rgb(16, 11, 8) 0%,
+    rgb(8, 6, 4) 100%
+  );
   backdrop-filter: blur(32px);
   -webkit-backdrop-filter: blur(32px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
+  border: 1px solid rgba(239, 111, 47, 0.07);
   box-shadow:
-    0 4px 24px rgba(0, 0, 0, 0.3),
-    0 0 0 0.5px rgba(0, 0, 0, 0.4),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    0 4px 24px rgba(0, 0, 0, 0.45),
+    0 0 0 0.5px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(239, 111, 47, 0.04);
   opacity: 0;
   transform: scale(0.85);
   overflow: hidden;
@@ -47,7 +50,8 @@
     opacity 200ms 60ms ease-in,
     transform 220ms cubic-bezier(0.55, 0, 1, 0.45),
     width 220ms cubic-bezier(0.55, 0, 1, 0.45),
-    height 220ms cubic-bezier(0.55, 0, 1, 0.45);
+    height 220ms cubic-bezier(0.55, 0, 1, 0.45),
+    border-radius 220ms cubic-bezier(0.55, 0, 1, 0.45);
   box-sizing: border-box;
 }
 
@@ -59,7 +63,8 @@
     opacity 180ms ease-out,
     transform 280ms cubic-bezier(0.34, 1.56, 0.64, 1),
     width 280ms cubic-bezier(0.16, 1, 0.3, 1),
-    height 280ms cubic-bezier(0.16, 1, 0.3, 1);
+    height 280ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-radius 280ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* Fade-in any new content block */
@@ -73,22 +78,23 @@
   }
 }
 
-/* Audio dots */
+/* Audio dots — tapered cluster with per-dot glow */
 .dots-container {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 2px;
+  gap: 1.5px;
   height: 24px;
   overflow: visible;
 }
 
 .dot {
+  /* width overridden by inline style for tapered widths */
   width: 2px;
   height: 2px;
   border-radius: 50%;
   background: #ef6f2f;
-  will-change: height, opacity;
+  will-change: height, opacity, box-shadow;
 }
 
 /* Streaming text — multi-line, up to 5 lines */
@@ -106,33 +112,57 @@
   box-sizing: border-box;
 }
 
-/* Word-by-word appear animation */
+/* Word-by-word appear — flash warm orange then settle to white */
 .word-appear {
-  animation: word-appear 200ms ease-out;
+  animation: word-appear 380ms ease-out;
 }
 
 @keyframes word-appear {
-  from {
+  0% {
     opacity: 0;
+    color: #ef6f2f;
     filter: blur(4px);
   }
-  to {
+  35% {
     opacity: 1;
+    color: #ef6f2f;
+    filter: blur(0);
+  }
+  100% {
+    opacity: 1;
+    color: rgba(255, 255, 255, 0.92);
     filter: blur(0);
   }
 }
 
-/* Post-processing: left-to-right fill */
+/* Post-processing: gradient fill with glowing leading edge */
 .progress-fill {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: rgba(239, 111, 47, 0.18);
+  background: linear-gradient(
+    90deg,
+    rgba(239, 111, 47, 0.08) 0%,
+    rgba(239, 111, 47, 0.14) 70%,
+    rgba(239, 111, 47, 0.28) 95%,
+    rgba(239, 111, 47, 0.45) 100%
+  );
   pointer-events: none;
   transition: width 150ms ease-out;
 }
 
-/* Thinking dots — sequential bounce */
+.progress-fill::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -1px;
+  bottom: 0;
+  width: 4px;
+  background: rgba(239, 111, 47, 0.5);
+  filter: blur(4px);
+}
+
+/* Thinking dots — smooth sinusoidal wave */
 .thinking-dots {
   display: flex;
   align-items: center;
@@ -148,20 +178,19 @@
   height: 3px;
   border-radius: 50%;
   background: #ef6f2f;
-  opacity: 0.5;
-  animation: thinking-bounce 600ms ease-in-out infinite;
+  opacity: 0.35;
+  animation: thinking-wave 1.4s ease-in-out infinite;
   will-change: transform, opacity;
 }
 
-@keyframes thinking-bounce {
+@keyframes thinking-wave {
   0%,
-  16.67%,
   100% {
-    transform: translateY(2px);
-    opacity: 0.5;
+    transform: translateY(1.5px);
+    opacity: 0.35;
   }
-  8.33% {
-    transform: translateY(-2px);
-    opacity: 1;
+  50% {
+    transform: translateY(-3px);
+    opacity: 0.9;
   }
 }

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -15,7 +15,9 @@ type OverlayState = "recording" | "transcribing" | "processing";
 
 const DOT_COUNT = 11;
 const THINKING_DOT_COUNT = 6;
-const LERP_SPEED = 0.12;
+const ATTACK_SPEED = 0.22;
+const DECAY_SPEED = 0.07;
+const ACCENT_RGB = "239, 111, 47";
 const STREAMING_WIDTH = 300;
 const STREAMING_LINE_HEIGHT = 18;
 const MAX_LINES = 5;
@@ -36,7 +38,7 @@ const RecordingOverlay: React.FC = () => {
   const dotElementsRef = useRef<(HTMLDivElement | null)[]>([]);
   const rafIdRef = useRef<number>(0);
   const frameCountRef = useRef(0);
-  const idleJitterRef = useRef<number[]>(Array(DOT_COUNT).fill(0));
+  const overlayRef = useRef<HTMLDivElement>(null);
 
   // Progress bar refs
   const progressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
@@ -74,6 +76,8 @@ const RecordingOverlay: React.FC = () => {
     return 33;
   })();
 
+  const overlayRadius = hasStreamingText ? 14 : 999;
+
   // Track words (runs before paint to avoid flicker)
   useLayoutEffect(() => {
     if (streamingText) {
@@ -93,32 +97,74 @@ const RecordingOverlay: React.FC = () => {
     }
   }, [streamingText]);
 
-  // rAF loop: lerp current toward target levels, write directly to DOM
+  // rAF loop: lerp toward target with asymmetric attack/decay,
+  // layered sine-wave idle, per-dot glow, ambient overlay glow
   const animateDots = useCallback(() => {
     const current = currentLevelsRef.current;
     const target = targetLevelsRef.current;
     const frame = frameCountRef.current++;
-    const jitter = idleJitterRef.current;
+    let totalEnergy = 0;
 
     for (let i = 0; i < DOT_COUNT; i++) {
-      current[i] += (target[i] - current[i]) * LERP_SPEED;
+      // Asymmetric LERP: snappy attack, slow lingering decay
+      const speed = target[i] > current[i] ? ATTACK_SPEED : DECAY_SPEED;
+      current[i] += (target[i] - current[i]) * speed;
+
       const el = dotElementsRef.current[i];
       if (el) {
         const v = current[i];
+        totalEnergy += v;
         const idleStrength = Math.max(0, 1 - v * 4);
 
-        // Idle: slow, gentle drift — update one random dot every ~12 frames
-        if (frame % 12 === i % 12) {
-          jitter[i] = Math.random() * 3 * idleStrength; // subtle 0–3px
-        }
+        // Idle: layered sine waves create a rolling wave across the dot array
+        const wave1 = Math.sin(frame * 0.02 + i * 0.5) * 0.5 + 0.5;
+        const wave2 = Math.sin(frame * 0.035 + i * 1.1) * 0.3 + 0.5;
+        const idleH = (wave1 * 1.8 + wave2 * 1.0) * idleStrength;
 
-        // Speaking: very drastic height, pow(0.4) makes even moderate levels tall
+        // Active: subtle vibrato adds organic tremor to speaking dots
+        const vibrato =
+          v > 0.05 ? Math.sin(frame * 0.15 + i * 2.0) * v * 1.5 : 0;
+
         const audioH = Math.pow(v, 0.4) * 22;
-        const h = 3 + audioH + jitter[i];
+        const h = 3 + audioH + idleH + vibrato;
         el.style.height = `${h}px`;
-        el.style.borderRadius = h > 3 ? "1px" : "50%";
-        el.style.opacity = `${0.4 + Math.min(0.6, v * 2)}`;
+        el.style.borderRadius = h > 4 ? "1px" : "50%";
+
+        // Opacity: idle dots gently pulse with the primary wave
+        const baseOpacity = 0.4 + Math.min(0.6, v * 2);
+        const idleOpacityMod = idleStrength * (wave1 * 0.12 - 0.04);
+        el.style.opacity = `${baseOpacity + idleOpacityMod}`;
+
+        // Per-dot glow: breathes with idle wave, flares when speaking
+        const idleGlow = idleStrength * wave1 * 0.15;
+        const activeGlow = Math.min(1, v * 2) * 0.6;
+        const glow = Math.max(idleGlow, activeGlow);
+        const glowRadius = 2 + v * 8 + idleStrength * wave1 * 2;
+        el.style.boxShadow =
+          glow > 0.03
+            ? `0 0 ${glowRadius}px rgba(${ACCENT_RGB}, ${glow})`
+            : "none";
       }
+    }
+
+    // Ambient overlay glow — breathes when idle, flares with voice
+    const overlay = overlayRef.current;
+    if (overlay) {
+      const avgEnergy = totalEnergy / DOT_COUNT;
+      const breathe = Math.sin(frame * 0.02) * 0.5 + 0.5;
+      const idleAmbient = avgEnergy < 0.05 ? breathe * 0.12 : 0;
+      const e = Math.max(Math.min(1, avgEnergy * 3), idleAmbient);
+      const glowBlur = 8 + e * 18;
+      const glowSpread = e * 4;
+      const glowAlpha = e * 0.3;
+      const innerAlpha = 0.03 + e * 0.06;
+      overlay.style.boxShadow = [
+        `0 0 ${glowBlur}px ${glowSpread}px rgba(${ACCENT_RGB}, ${glowAlpha})`,
+        "0 4px 24px rgba(0, 0, 0, 0.45)",
+        "0 0 0 0.5px rgba(0, 0, 0, 0.5)",
+        `inset 0 1px 0 rgba(${ACCENT_RGB}, 0.04)`,
+        `inset 0 0 16px rgba(${ACCENT_RGB}, ${innerAlpha})`,
+      ].join(", ");
     }
 
     rafIdRef.current = requestAnimationFrame(animateDots);
@@ -128,6 +174,8 @@ const RecordingOverlay: React.FC = () => {
   useEffect(() => {
     if (isVisible && state === "recording") {
       rafIdRef.current = requestAnimationFrame(animateDots);
+    } else if (overlayRef.current) {
+      overlayRef.current.style.boxShadow = "";
     }
     return () => cancelAnimationFrame(rafIdRef.current);
   }, [isVisible, state, animateDots]);
@@ -224,8 +272,13 @@ const RecordingOverlay: React.FC = () => {
   return (
     <div className={`overlay-wrapper position-${overlayPosition}`}>
       <div
+        ref={overlayRef}
         dir={direction}
-        style={{ width: overlayWidth, height: overlayHeight }}
+        style={{
+          width: overlayWidth,
+          height: overlayHeight,
+          borderRadius: overlayRadius,
+        }}
         className={`recording-overlay ${isVisible ? "fade-in" : ""}`}
       >
         {state === "recording" &&
@@ -242,15 +295,21 @@ const RecordingOverlay: React.FC = () => {
             </div>
           ) : (
             <div className="dots-container">
-              {Array.from({ length: DOT_COUNT }, (_, i) => (
-                <div
-                  key={i}
-                  className="dot"
-                  ref={(el) => {
-                    dotElementsRef.current[i] = el;
-                  }}
-                />
-              ))}
+              {Array.from({ length: DOT_COUNT }, (_, i) => {
+                const center = (DOT_COUNT - 1) / 2;
+                const dist = Math.abs(i - center) / center;
+                const w = 1.5 + (1 - dist * dist) * 1;
+                return (
+                  <div
+                    key={i}
+                    className="dot"
+                    style={{ width: w }}
+                    ref={(el) => {
+                      dotElementsRef.current[i] = el;
+                    }}
+                  />
+                );
+              })}
             </div>
           ))}
 
@@ -265,7 +324,7 @@ const RecordingOverlay: React.FC = () => {
                 <div
                   key={i}
                   className="thinking-dot"
-                  style={{ animationDelay: `${i * 100}ms` }}
+                  style={{ animationDelay: `${i * 120}ms` }}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Polish recording overlay with warm-tinted surface, ambient orange glow that breathes idle and flares with voice energy, asymmetric attack/decay lerp, layered sine-wave idle animation, per-dot glow, and tapered dot widths
- Enhance word-appear animation (flash orange → settle white), progress fill (gradient + glowing edge), and thinking dots (smooth sinusoidal wave)
- Extract `ACCENT_RGB` constant to replace 4 scattered hardcoded `rgba(239, 111, 47, ...)` values in animation JS
- Fix stale closure bug in `Cmd+[/]` shortcut handler — depend on full `settings` object instead of just `settings?.debug_mode`

## Test plan
- [ ] Verify recording overlay idle animation shows rolling sine wave across dots
- [ ] Verify speaking causes snappy attack with lingering decay on dots
- [ ] Verify ambient overlay glow breathes when idle and flares with voice
- [ ] Verify word-appear text flashes orange then settles to white
- [ ] Verify progress fill shows gradient with glowing leading edge
- [ ] Verify thinking dots animate with smooth wave instead of bounce
- [ ] Verify Cmd+[ / Cmd+] navigates sidebar sections correctly