### PR TITLE
refactor(models): simplify cloud verified badge

### DIFF
--- a/src/components/settings/models/CloudProviderConfigCard.tsx
+++ b/src/components/settings/models/CloudProviderConfigCard.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  Check,
   CaretDown,
   Cloud,
   ArrowSquareOut,
@@ -248,15 +247,9 @@ export const CloudProviderConfigCard: React.FC<
         >
           {provider.name}
         </h3>
-        <Badge variant="secondary">
+        <Badge variant={isVerified ? "success" : "secondary"}>
           <Cloud className="w-3 h-3" />
         </Badge>
-        {isVerified && (
-          <Badge variant="success">
-            <Check className="w-3 h-3 mr-1" />
-            {t("settings.models.cloudProviders.verified")}
-          </Badge>
-        )}
         {effectiveStatus === "active" && (
           <Badge variant="default">{t("modelSelector.active")}</Badge>
         )}


### PR DESCRIPTION
## Summary
- Merge the separate verified badge into the existing cloud badge by switching its variant from `secondary` to `success` when verified
- Remove the redundant `Check` icon and "Verified" text label — the green color alone communicates the state
- Clean up unused `Check` import

## Test plan
- [ ] Verify cloud provider card shows neutral cloud badge when unverified
- [ ] Verify cloud provider card shows green cloud badge after successful API key verification