### PR TITLE
refactor(overlay): normalize accent color to CSS custom properties

### DIFF
--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -174,7 +174,7 @@ const ModelCard: React.FC<ModelCardProps> = ({
 
       {/* Description */}
       <p
-        className={`text-text/60 text-sm ${compact ? "leading-snug" : "leading-relaxed"}`}
+        className={`text-text/60 text-sm break-words ${compact ? "leading-snug" : "leading-relaxed"}`}
       >
         {isCloud && configuredModel ? configuredModel : displayDescription}
       </p>

--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -7,6 +7,11 @@
   font-display: swap;
 }
 
+:root {
+  --color-accent: #ef6f2f;
+  --color-accent-rgb: 239, 111, 47;
+}
+
 .overlay-wrapper {
   width: 100%;
   height: 100%;
@@ -37,11 +42,11 @@
   );
   backdrop-filter: blur(32px);
   -webkit-backdrop-filter: blur(32px);
-  border: 1px solid rgba(239, 111, 47, 0.07);
+  border: 1px solid rgba(var(--color-accent-rgb), 0.07);
   box-shadow:
     0 4px 24px rgba(0, 0, 0, 0.45),
     0 0 0 0.5px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(239, 111, 47, 0.04);
+    inset 0 1px 0 rgba(var(--color-accent-rgb), 0.04);
   opacity: 0;
   transform: scale(0.85);
   overflow: hidden;
@@ -93,7 +98,7 @@
   width: 2px;
   height: 2px;
   border-radius: 50%;
-  background: #ef6f2f;
+  background: var(--color-accent);
   will-change: height, opacity, box-shadow;
 }
 
@@ -120,12 +125,12 @@
 @keyframes word-appear {
   0% {
     opacity: 0;
-    color: #ef6f2f;
+    color: var(--color-accent);
     filter: blur(4px);
   }
   35% {
     opacity: 1;
-    color: #ef6f2f;
+    color: var(--color-accent);
     filter: blur(0);
   }
   100% {
@@ -142,10 +147,10 @@
   border-radius: inherit;
   background: linear-gradient(
     90deg,
-    rgba(239, 111, 47, 0.08) 0%,
-    rgba(239, 111, 47, 0.14) 70%,
-    rgba(239, 111, 47, 0.28) 95%,
-    rgba(239, 111, 47, 0.45) 100%
+    rgba(var(--color-accent-rgb), 0.08) 0%,
+    rgba(var(--color-accent-rgb), 0.14) 70%,
+    rgba(var(--color-accent-rgb), 0.28) 95%,
+    rgba(var(--color-accent-rgb), 0.45) 100%
   );
   pointer-events: none;
   transition: width 150ms ease-out;
@@ -158,7 +163,7 @@
   right: -1px;
   bottom: 0;
   width: 4px;
-  background: rgba(239, 111, 47, 0.5);
+  background: rgba(var(--color-accent-rgb), 0.5);
   filter: blur(4px);
 }
 
@@ -177,7 +182,7 @@
   width: 3px;
   height: 3px;
   border-radius: 50%;
-  background: #ef6f2f;
+  background: var(--color-accent);
   opacity: 0.35;
   animation: thinking-wave 1.4s ease-in-out infinite;
   will-change: transform, opacity;

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -17,7 +17,6 @@ const DOT_COUNT = 11;
 const THINKING_DOT_COUNT = 6;
 const ATTACK_SPEED = 0.22;
 const DECAY_SPEED = 0.07;
-const ACCENT_RGB = "239, 111, 47";
 const STREAMING_WIDTH = 300;
 const STREAMING_LINE_HEIGHT = 18;
 const MAX_LINES = 5;
@@ -31,6 +30,14 @@ const RecordingOverlay: React.FC = () => {
     "top",
   );
   const [progress, setProgress] = useState(0);
+
+  // Accent RGB resolved from CSS variable for use in inline box-shadow strings
+  const accentRgbRef = useRef("239, 111, 47");
+  useEffect(() => {
+    accentRgbRef.current = getComputedStyle(document.documentElement)
+      .getPropertyValue("--color-accent-rgb")
+      .trim();
+  }, []);
 
   // Dot animation via rAF — bypasses React rendering
   const targetLevelsRef = useRef<number[]>(Array(DOT_COUNT).fill(0));
@@ -142,7 +149,7 @@ const RecordingOverlay: React.FC = () => {
         const glowRadius = 2 + v * 8 + idleStrength * wave1 * 2;
         el.style.boxShadow =
           glow > 0.03
-            ? `0 0 ${glowRadius}px rgba(${ACCENT_RGB}, ${glow})`
+            ? `0 0 ${glowRadius}px rgba(${accentRgbRef.current}, ${glow})`
             : "none";
       }
     }
@@ -159,11 +166,11 @@ const RecordingOverlay: React.FC = () => {
       const glowAlpha = e * 0.3;
       const innerAlpha = 0.03 + e * 0.06;
       overlay.style.boxShadow = [
-        `0 0 ${glowBlur}px ${glowSpread}px rgba(${ACCENT_RGB}, ${glowAlpha})`,
+        `0 0 ${glowBlur}px ${glowSpread}px rgba(${accentRgbRef.current}, ${glowAlpha})`,
         "0 4px 24px rgba(0, 0, 0, 0.45)",
         "0 0 0 0.5px rgba(0, 0, 0, 0.5)",
-        `inset 0 1px 0 rgba(${ACCENT_RGB}, 0.04)`,
-        `inset 0 0 16px rgba(${ACCENT_RGB}, ${innerAlpha})`,
+        `inset 0 1px 0 rgba(${accentRgbRef.current}, 0.04)`,
+        `inset 0 0 16px rgba(${accentRgbRef.current}, ${innerAlpha})`,
       ].join(", ");
     }
 


### PR DESCRIPTION
## Summary
- Replace 6 hard-coded `#ef6f2f` / `rgba(239, 111, 47, ...)` values in the overlay with `--color-accent` and `--color-accent-rgb` CSS custom properties defined in a `:root` block in `RecordingOverlay.css`
- JS rAF loop (`animateDots`) now reads the RGB token via `getComputedStyle` at mount instead of a hard-coded `ACCENT_RGB` constant — inline `boxShadow` strings stay in sync automatically
- Add `break-words` to `ModelCard` description paragraph to prevent overflow on long model names

## Test plan
- [ ] Launch the overlay and confirm recording dots, thinking dots, word-appear flash, and progress fill all render with the correct orange accent
- [ ] Confirm ambient glow in the rAF loop still fires (dot glow + overlay glow) with correct color
- [ ] Update `--color-accent` in `RecordingOverlay.css` `:root` to a different color and verify all overlay elements update from that single change