### PR TITLE
Refactor: Move model descriptions to translation files

### DIFF
--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -99,7 +99,7 @@ impl ModelManager {
             ModelInfo {
                 id: "small".to_string(),
                 name: "Whisper Small".to_string(),
-                description: "Fast and fairly accurate.".to_string(),
+                description: "onboarding.models.small.description".to_string(),
                 filename: "ggml-small.bin".to_string(),
                 url: Some("https://blob.handy.computer/ggml-small.bin".to_string()),
                 size_mb: 487,
@@ -123,7 +123,7 @@ impl ModelManager {
             ModelInfo {
                 id: "medium".to_string(),
                 name: "Whisper Medium".to_string(),
-                description: "Good accuracy, medium speed".to_string(),
+                description: "onboarding.models.medium.description".to_string(),
                 filename: "whisper-medium-q4_1.bin".to_string(),
                 url: Some("https://blob.handy.computer/whisper-medium-q4_1.bin".to_string()),
                 size_mb: 492, // Approximate size
@@ -146,7 +146,7 @@ impl ModelManager {
             ModelInfo {
                 id: "turbo".to_string(),
                 name: "Whisper Turbo".to_string(),
-                description: "Balanced accuracy and speed.".to_string(),
+                description: "onboarding.models.turbo.description".to_string(),
                 filename: "ggml-large-v3-turbo.bin".to_string(),
                 url: Some("https://blob.handy.computer/ggml-large-v3-turbo.bin".to_string()),
                 size_mb: 1600, // Approximate size
@@ -169,7 +169,7 @@ impl ModelManager {
             ModelInfo {
                 id: "large".to_string(),
                 name: "Whisper Large".to_string(),
-                description: "Good accuracy, but slow.".to_string(),
+                description: "onboarding.models.large.description".to_string(),
                 filename: "ggml-large-v3-q5_0.bin".to_string(),
                 url: Some("https://blob.handy.computer/ggml-large-v3-q5_0.bin".to_string()),
                 size_mb: 1100, // Approximate size
@@ -192,8 +192,7 @@ impl ModelManager {
             ModelInfo {
                 id: "breeze-asr".to_string(),
                 name: "Breeze ASR".to_string(),
-                description: "Optimized for Taiwanese Mandarin. Code-switching support."
-                    .to_string(),
+                description: "onboarding.models.breeze-asr.description".to_string(),
                 filename: "breeze-asr-q5_k.bin".to_string(),
                 url: Some("https://blob.handy.computer/breeze-asr-q5_k.bin".to_string()),
                 size_mb: 1080,
@@ -217,7 +216,7 @@ impl ModelManager {
             ModelInfo {
                 id: "parakeet-tdt-0.6b-v2".to_string(),
                 name: "Parakeet V2".to_string(),
-                description: "English only. The best model for English speakers.".to_string(),
+                description: "onboarding.models.parakeet-tdt-0.6b-v2.description".to_string(),
                 filename: "parakeet-tdt-0.6b-v2-int8".to_string(), // Directory name
                 url: Some("https://blob.handy.computer/parakeet-v2-int8.tar.gz".to_string()),
                 size_mb: 473, // Approximate size for int8 quantized model
@@ -250,7 +249,7 @@ impl ModelManager {
             ModelInfo {
                 id: "parakeet-tdt-0.6b-v3".to_string(),
                 name: "Parakeet V3".to_string(),
-                description: "Fast and accurate. Supports 25 European languages.".to_string(),
+                description: "onboarding.models.parakeet-tdt-0.6b-v3.description".to_string(),
                 filename: "parakeet-tdt-0.6b-v3-int8".to_string(), // Directory name
                 url: Some("https://blob.handy.computer/parakeet-v3-int8.tar.gz".to_string()),
                 size_mb: 478, // Approximate size for int8 quantized model
@@ -273,7 +272,7 @@ impl ModelManager {
             ModelInfo {
                 id: "moonshine-base".to_string(),
                 name: "Moonshine Base".to_string(),
-                description: "Very fast, English only. Handles accents well.".to_string(),
+                description: "onboarding.models.moonshine-base.description".to_string(),
                 filename: "moonshine-base".to_string(),
                 url: Some("https://blob.handy.computer/moonshine-base.tar.gz".to_string()),
                 size_mb: 58,
@@ -296,7 +295,7 @@ impl ModelManager {
             ModelInfo {
                 id: "moonshine-tiny-streaming-en".to_string(),
                 name: "Moonshine V2 Tiny".to_string(),
-                description: "Ultra-fast, English only".to_string(),
+                description: "onboarding.models.moonshine-tiny-streaming-en.description".to_string(),
                 filename: "moonshine-tiny-streaming-en".to_string(),
                 url: Some(
                     "https://blob.handy.computer/moonshine-tiny-streaming-en.tar.gz".to_string(),
@@ -321,7 +320,7 @@ impl ModelManager {
             ModelInfo {
                 id: "moonshine-small-streaming-en".to_string(),
                 name: "Moonshine V2 Small".to_string(),
-                description: "Fast, English only. Good balance of speed and accuracy.".to_string(),
+                description: "onboarding.models.moonshine-small-streaming-en.description".to_string(),
                 filename: "moonshine-small-streaming-en".to_string(),
                 url: Some(
                     "https://blob.handy.computer/moonshine-small-streaming-en.tar.gz".to_string(),
@@ -346,7 +345,7 @@ impl ModelManager {
             ModelInfo {
                 id: "moonshine-medium-streaming-en".to_string(),
                 name: "Moonshine V2 Medium".to_string(),
-                description: "English only. High quality.".to_string(),
+                description: "onboarding.models.moonshine-medium-streaming-en.description".to_string(),
                 filename: "moonshine-medium-streaming-en".to_string(),
                 url: Some(
                     "https://blob.handy.computer/moonshine-medium-streaming-en.tar.gz".to_string(),
@@ -378,8 +377,7 @@ impl ModelManager {
             ModelInfo {
                 id: "sense-voice-int8".to_string(),
                 name: "SenseVoice".to_string(),
-                description: "Very fast. Chinese, English, Japanese, Korean, Cantonese."
-                    .to_string(),
+                description: "onboarding.models.sense-voice-int8.description".to_string(),
                 filename: "sense-voice-int8".to_string(),
                 url: Some("https://blob.handy.computer/sense-voice-int8.tar.gz".to_string()),
                 size_mb: 160,
@@ -688,7 +686,7 @@ impl ModelManager {
                 ModelInfo {
                     id: model_id,
                     name: display_name,
-                    description: "Not officially supported".to_string(),
+                    description: "onboarding.customModelDescription".to_string(),
                     filename,
                     url: None, // Custom models have no download URL
                     size_mb,

--- a/src-tauri/src/stt_provider.rs
+++ b/src-tauri/src/stt_provider.rs
@@ -62,7 +62,7 @@ pub fn cloud_provider_registry() -> Vec<SttProviderInfo> {
         SttProviderInfo {
             id: "openai_stt".to_string(),
             name: "OpenAI".to_string(),
-            description: "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages.".to_string(),
+            description: "onboarding.cloud.openai_stt.description".to_string(),
             supported_languages: vec![
                 "af", "ar", "hy", "az", "be", "bs", "bg", "ca", "zh-Hans", "zh-Hant", "hr",
                 "cs", "da", "nl", "en", "et", "fi", "fr", "gl", "de", "el",
@@ -103,7 +103,7 @@ pub fn cloud_provider_registry() -> Vec<SttProviderInfo> {
         SttProviderInfo {
             id: "soniox".to_string(),
             name: "Soniox".to_string(),
-            description: "Soniox cloud speech-to-text. High accuracy with realtime transcription.".to_string(),
+            description: "onboarding.cloud.soniox.description".to_string(),
             supported_languages: vec![
                 "af", "sq", "ar", "az", "eu", "be", "bn", "bs", "bg", "ca",
                 "zh-Hans", "zh-Hant", "hr", "cs", "da", "nl", "en", "et", "fi", "fr",

--- a/src/components/model-selector/ModelDropdown.tsx
+++ b/src/components/model-selector/ModelDropdown.tsx
@@ -2,10 +2,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Cloud } from "@phosphor-icons/react";
 import type { SttProviderInfo } from "@/bindings";
-import {
-  getTranslatedModelName,
-  getTranslatedModelDescription,
-} from "../../lib/utils/modelTranslation";
+import { getTranslatedModelName } from "../../lib/utils/modelTranslation";
 
 interface DropdownItemProps {
   active: boolean;
@@ -114,7 +111,7 @@ const ModelDropdown: React.FC<ModelDropdownProps> = ({
                       )}
                   </div>
                   <div className="text-[11px] text-text/30 mt-0.5 leading-snug">
-                    {getTranslatedModelDescription(provider, t)}
+                    {t(provider.description)}
                   </div>
                 </DropdownItem>
               ))}
@@ -137,11 +134,11 @@ const ModelDropdown: React.FC<ModelDropdownProps> = ({
                   onClick={() => handleClick(provider)}
                 >
                   <div className="text-[13px] leading-tight flex items-center gap-1.5">
-                    {provider.name}
+                    {getTranslatedModelName(provider, t)}
                     <Cloud weight="fill" className="w-3 h-3 text-text/20" />
                   </div>
                   <div className="text-[11px] text-text/30 mt-0.5 leading-snug">
-                    {provider.description}
+                    {t(provider.description)}
                   </div>
                 </DropdownItem>
               ))}

--- a/src/components/onboarding/ModelCard.tsx
+++ b/src/components/onboarding/ModelCard.tsx
@@ -18,7 +18,6 @@ import { spring } from "../../lib/motion";
 import { formatModelSize } from "../../lib/utils/format";
 import {
   getLanguageDisplayText,
-  getTranslatedModelDescription,
   getTranslatedModelName,
 } from "../../lib/utils/modelTranslation";
 import Badge from "../ui/Badge";
@@ -102,7 +101,7 @@ const ModelCard: React.FC<ModelCardProps> = ({
 
   // Get translated model name and description
   const displayName = getTranslatedModelName(provider, t);
-  const displayDescription = getTranslatedModelDescription(provider, t);
+  const displayDescription = t(provider.description);
 
   const handleClick = () => {
     if (status === "downloadable" && onDownload && isLocal) {

--- a/src/components/settings/models/CloudProviderConfigCard.tsx
+++ b/src/components/settings/models/CloudProviderConfigCard.tsx
@@ -19,7 +19,7 @@ import { SelectableCard } from "@/components/ui/SelectableCard";
 import type { CloudProviderOption, SttProviderInfo } from "@/bindings";
 import type { ModelCardStatus } from "@/components/onboarding/ModelCard";
 import { LANGUAGES } from "@/lib/constants/languages";
-import { getLanguageDisplayText } from "@/lib/utils/modelTranslation";
+import { getLanguageDisplayText, getTranslatedModelName } from "@/lib/utils/modelTranslation";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { Checkbox } from "@/components/ui/Checkbox";
@@ -245,7 +245,7 @@ export const CloudProviderConfigCard: React.FC<
         <h3
           className={`text-base font-semibold text-text ${isClickable ? "group-hover:text-accent" : ""} transition-colors`}
         >
-          {provider.name}
+          {getTranslatedModelName(provider, t)}
         </h3>
         <Badge variant={isVerified ? "success" : "secondary"}>
           <Cloud className="w-3 h-3" />
@@ -275,13 +275,11 @@ export const CloudProviderConfigCard: React.FC<
       </div>
 
       {/* Description */}
-      {provider.description && (
-        <p
-          className={`text-text/60 text-sm ${compact ? "leading-snug" : "leading-relaxed"}`}
-        >
-          {provider.description}
-        </p>
-      )}
+      <p
+        className={`text-text/60 text-sm ${compact ? "leading-snug" : "leading-relaxed"}`}
+      >
+        {t(provider.description)}
+      </p>
 
       {/* Inline config fields */}
       {expanded && (

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": ".سريع ودقيق"
+        "description": "سريع ودقيق. يدعم 25 لغة أوروبية."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "واجهة برمجة تطبيقات تحويل الكلام إلى نص السحابية من OpenAI. سريعة ودقيقة مع دعم لأكثر من 57 لغة."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "تحويل الكلام إلى نص السحابي من Soniox. دقة عالية مع تفريغ في الوقت الفعلي."
       }
     }
   },
@@ -143,7 +143,7 @@
       "translation": "يدعم الترجمة",
       "translate": "ترجمة"
     },
-    "notAvailable": "Not Available"
+    "notAvailable": "غير متاح"
   },
   "settings": {
     "general": {
@@ -188,11 +188,11 @@
         "description": "استمر في الضغط للتسجيل، واترك للتوقف"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "الاختصارات",
+        "strategyNone": "بلا",
+        "addNew": "إضافة اختصار",
+        "remove": "إزالة الاختصار",
+        "postProcessNotReady": "قم بتكوين مزود المعالجة اللاحقة أولاً"
       }
     },
     "sound": {
@@ -221,7 +221,7 @@
         "output": "الإخراج",
         "transcription": "التفريغ الصوتي",
         "history": "السجل",
-        "data": "Data",
+        "data": "البيانات",
         "configuration": "الإعدادات"
       },
       "startHidden": {
@@ -256,7 +256,7 @@
           "none": "بلا",
           "externalScript": "نص برمجي خارجي"
         },
-        "externalScriptPlaceholder": "/path/to/your/script.sh"
+        "externalScriptPlaceholder": "/المسار/إلى/السكربت.sh"
       },
       "typingTool": {
         "title": "أداة الكتابة",
@@ -312,39 +312,39 @@
         "duplicate": "\"{{word}}\" موجود بالفعل"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "تصدير البيانات",
+        "description": "تصدير إعداداتك وسجلك وتسجيلاتك إلى ملف",
+        "button": "...تصدير",
+        "includeSettings": "الإعدادات",
+        "includeHistory": "سجل التفريغ الصوتي",
+        "includeRecordings": "التسجيلات الصوتية",
+        "success": "تم تصدير البيانات بنجاح",
+        "error": "فشل تصدير البيانات"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "استيراد البيانات",
+        "description": "استيراد الإعدادات والبيانات من ملف تم تصديره مسبقاً",
+        "button": "...استيراد",
+        "previewTitle": "معاينة الاستيراد",
+        "exportDate": "تم التصدير في {{date}}",
+        "appVersion": "إصدار التطبيق: {{version}}",
+        "historyCount": "{{count}} إدخالات في السجل",
+        "recordingsCount": "{{count}} تسجيلات",
+        "statsCount": "{{count}} إحصائيات التحدث",
+        "importSettings": "الإعدادات",
+        "importRecordings": "التسجيلات",
+        "warning": "سيؤدي استيراد الإعدادات إلى الكتابة فوق التكوين الحالي. قد يحتوي ملف التصدير على مفاتيح API.",
+        "success": "تم استيراد البيانات بنجاح",
+        "error": "فشل استيراد البيانات",
+        "invalidFile": "الملف المحدد ليس ملف تصدير Handless صالحاً"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "السمة",
+        "description": "اختر سمة ألوان التطبيق",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "داكن",
+          "light": "فاتح",
+          "system": "النظام"
         }
       },
       "configFile": {
@@ -448,8 +448,8 @@
       "unsave": "إزالة من المحفوظات",
       "delete": "حذف الإدخال",
       "deleteError": ".فشل حذف الإدخال. يرجى المحاولة مرة أخرى",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "إخفاء الأصل",
+      "showOriginal": "إظهار الأصل"
     },
     "debug": {
       "title": "تصحيح الأخطاء",
@@ -468,7 +468,7 @@
       "soundTheme": {
         "label": "سمة الصوت",
         "description": "اختر سمة صوت لتنبيهات بدء وتوقف التسجيل",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "معاينة سمة الصوت (تشغيل البدء ثم التوقف)"
       },
       "wordCorrectionThreshold": {
         "title": "عتبة تصحيح الكلمات",
@@ -566,60 +566,60 @@
       },
       "noModelsMatch": "لا توجد نماذج مطابقة لهذا الفلتر.",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "نماذجي",
+        "library": "المكتبة"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "مزودو الخدمات السحابية",
+        "badge": "سحابي",
+        "notConfigured": "غير مُكوَّن",
+        "verify": "تحقق",
+        "verifying": "...جاري التحقق",
+        "verified": "تم التحقق",
+        "verifyFailed": "فشل التحقق",
+        "verifyFirst": "تحقق من مفتاح API الخاص بك أولاً",
         "apiKey": {
-          "title": "API Key",
+          "title": "مفتاح API",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "النموذج",
+          "placeholder": "أدخل اسم النموذج"
         },
         "baseUrl": {
-          "title": "Base URL"
+          "title": "عنوان URL الأساسي"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "الحصول على مفتاح API",
+        "realtimeTranscription": "التفريغ الفوري",
+        "realtimeDescription": "يستخدم اتصال WebSocket بدلاً من رفع الملفات لتقليل زمن الاستجابة",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
-          "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "language": "اللغة",
+          "selectLanguage": "كشف تلقائي",
+          "selectLanguageHint": "اتركه فارغاً للكشف التلقائي",
+          "selectLanguages": "...اختر اللغات",
+          "selectTranslate": "...اختر اللغات",
+          "prompt": "المطالبة",
+          "promptDescription": "نص اختياري لتوجيه أسلوب النموذج أو متابعة مقطع سابق. غير مدعوم بواسطة gpt-4o-transcribe-diarize.",
+          "temperature": "درجة الحرارة",
+          "temperatureDescription": "القيم الأعلى تنتج نتائج أكثر عشوائية (0-1). مدعوم فقط بواسطة whisper-1.",
+          "languageHints": "تلميحات اللغة",
+          "languageHintsStrict": "تلميحات لغة صارمة",
+          "languageHintsStrictDescription": "التفريغ فقط باللغات المحددة",
+          "contextTerms": "مصطلحات السياق",
+          "contextTermsDescription": "مصطلحات مفصولة بفواصل لتحسين دقة التعرف",
+          "contextDescription": "وصف السياق",
+          "contextDescriptionDescription": "نص حر يوفر سياقاً عاماً حول محتوى الصوت",
+          "enableSpeakerDiarization": "تمييز المتحدثين",
+          "enableSpeakerDiarizationDescription": "تحديد وفصل المتحدثين المختلفين",
+          "enableLanguageIdentification": "تحديد اللغة",
+          "enableLanguageIdentificationDescription": "اكتشاف اللغة لكل مقطع"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "النماذج المحلية"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "لم يتم تكوين أي نماذج. قم بزيارة المكتبة لتنزيل النماذج أو إعداد مزودي الخدمات السحابية."
       }
     }
   },
@@ -659,8 +659,8 @@
     "yes": "نعم",
     "no": "لا",
     "noOptionsFound": "لم يتم العثور على خيارات",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "نسخ إلى الحافظة",
+    "search": "...بحث"
   },
   "accessibility": {
     "permissionsRequired": "أذونات إمكانية الوصول مطلوبة",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Rychlý a přesný"
+        "description": "Rychlý a přesný. Podporuje 25 evropských jazyků."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "Cloudové API pro převod řeči na text od OpenAI. Rychlé a přesné s podporou více než 57 jazyků."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Cloudový převod řeči na text Soniox. Vysoká přesnost s přepisem v reálném čase."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Zrušit",
     "cancelDownload": "Zrušit stahování",
-    "notAvailable": "Not Available"
+    "notAvailable": "Nedostupné"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Stažené modely",
       "availableModels": "Dostupné ke stažení",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Moje modely",
+        "library": "Knihovna"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
+        "title": "Cloudoví poskytovatelé",
         "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "notConfigured": "Nenastaveno",
+        "verify": "Ověřit",
+        "verifying": "Ověřování...",
+        "verified": "Ověřeno",
+        "verifyFailed": "Ověření selhalo",
+        "verifyFirst": "Nejprve ověřte svůj API klíč",
         "apiKey": {
-          "title": "API Key",
+          "title": "API klíč",
           "placeholder": "sk-..."
         },
         "model": {
           "title": "Model",
-          "placeholder": "Enter model name"
+          "placeholder": "Zadejte název modelu"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Získat API klíč",
+        "realtimeTranscription": "Přepis v reálném čase",
+        "realtimeDescription": "Používá WebSocket připojení místo nahrání souboru pro nižší latenci",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Jazyk",
+          "selectLanguage": "Automatická detekce",
+          "selectLanguageHint": "Ponechte prázdné pro automatickou detekci",
+          "selectLanguages": "Vyberte jazyky...",
+          "selectTranslate": "Vyberte jazyky...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Volitelný text pro navádění stylu modelu nebo pokračování předchozího segmentu. Nepodporováno u gpt-4o-transcribe-diarize.",
+          "temperature": "Teplota",
+          "temperatureDescription": "Vyšší hodnoty produkují náhodnější výsledky (0–1). Podporováno pouze u whisper-1.",
+          "languageHints": "Jazykové nápovědy",
+          "languageHintsStrict": "Striktní jazykové nápovědy",
+          "languageHintsStrictDescription": "Přepisovat pouze v zadaných jazycích",
+          "contextTerms": "Kontextové výrazy",
+          "contextTermsDescription": "Výrazy oddělené čárkami pro zlepšení přesnosti rozpoznávání",
+          "contextDescription": "Popis kontextu",
+          "contextDescriptionDescription": "Volný text poskytující obecný kontext o obsahu zvuku",
+          "enableSpeakerDiarization": "Diarizace mluvčích",
+          "enableSpeakerDiarizationDescription": "Identifikovat a oddělit různé mluvčí",
+          "enableLanguageIdentification": "Identifikace jazyka",
+          "enableLanguageIdentificationDescription": "Detekovat jazyk pro každý segment"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Lokální modely"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Žádné modely nejsou nastaveny. Navštivte Knihovnu pro stažení modelů nebo nastavení cloudových poskytovatelů."
       }
     },
     "general": {
@@ -259,18 +259,18 @@
         "descriptionUnsupported": "Model Parakeet rozpozná jazyk automaticky. Ruční výběr není potřeba.",
         "searchPlaceholder": "Hledat jazyky...",
         "noResults": "Žádné jazyky nenalezeny",
-        "auto": "Auto"
+        "auto": "Automaticky"
       },
       "pushToTalk": {
         "label": "Stisk a mluv",
         "description": "Podržte pro nahrávání, uvolněte pro zastavení"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Zkratky",
+        "strategyNone": "Žádné",
+        "addNew": "Přidat zkratku",
+        "remove": "Odebrat zkratku",
+        "postProcessNotReady": "Nejprve nastavte poskytovatele následného zpracování"
       }
     },
     "sound": {
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" již existuje"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Export dat",
+        "description": "Exportovat nastavení, historii a nahrávky do souboru",
+        "button": "Exportovat...",
+        "includeSettings": "Nastavení",
+        "includeHistory": "Historie přepisů",
+        "includeRecordings": "Zvukové nahrávky",
+        "success": "Data byla úspěšně exportována",
+        "error": "Export dat se nezdařil"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Import dat",
+        "description": "Importovat nastavení a data z dříve exportovaného souboru",
+        "button": "Importovat...",
+        "previewTitle": "Náhled importu",
+        "exportDate": "Exportováno dne {{date}}",
+        "appVersion": "Verze aplikace: {{version}}",
+        "historyCount": "{{count}} záznamů historie",
+        "recordingsCount": "{{count}} nahrávek",
+        "statsCount": "{{count}} statistik mluvení",
+        "importSettings": "Nastavení",
+        "importRecordings": "Nahrávky",
+        "warning": "Import nastavení přepíše vaši aktuální konfiguraci. Exportovaný soubor může obsahovat API klíče.",
+        "success": "Data byla úspěšně importována",
+        "error": "Import dat se nezdařil",
+        "invalidFile": "Vybraný soubor není platný export Handless"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Motiv",
+        "description": "Vyberte barevný motiv aplikace",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Tmavý",
+          "light": "Světlý",
+          "system": "Systémový"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "Odebrat z uložených",
       "delete": "Smazat záznam",
       "deleteError": "Nepodařilo se smazat záznam. Zkuste to prosím znovu.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Skrýt originál",
+      "showOriginal": "Zobrazit originál"
     },
     "debug": {
       "title": "Ladění",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Zvukový motiv",
         "description": "Vyberte zvukový motiv pro odezvu při startu a ukončení nahrávání",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Přehrát ukázku zvukového motivu (přehraje start a poté stop)"
       },
       "wordCorrectionThreshold": {
         "title": "Práh korekce slov",
@@ -659,8 +659,8 @@
     "yes": "Ano",
     "no": "Ne",
     "noOptionsFound": "Nenalezeny žádné možnosti",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Kopírovat do schránky",
+    "search": "Hledat..."
   },
   "accessibility": {
     "permissionsRequired": "Vyžadována oprávnění usnadnění přístupu",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Schnell und genau"
+        "description": "Schnell und genau. Unterstützt 25 europäische Sprachen."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "OpenAIs Cloud-Sprache-zu-Text-API. Schnell und genau mit Unterstützung für über 57 Sprachen."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Soniox Cloud-Sprache-zu-Text. Hohe Genauigkeit mit Echtzeit-Transkription."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Abbrechen",
     "cancelDownload": "Download abbrechen",
-    "notAvailable": "Not Available"
+    "notAvailable": "Nicht verfügbar"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Heruntergeladene Modelle",
       "availableModels": "Zum Download verfügbar",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Meine Modelle",
+        "library": "Bibliothek"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
+        "title": "Cloud-Anbieter",
         "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "notConfigured": "Nicht konfiguriert",
+        "verify": "Verifizieren",
+        "verifying": "Verifiziere...",
+        "verified": "Verifiziert",
+        "verifyFailed": "Verifizierung fehlgeschlagen",
+        "verifyFirst": "Zuerst den API Key verifizieren",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Modell",
+          "placeholder": "Modellnamen eingeben"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "API Key erhalten",
+        "realtimeTranscription": "Echtzeit-Transkription",
+        "realtimeDescription": "Verwendet eine WebSocket-Verbindung statt Datei-Upload für geringere Latenz",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Sprache",
+          "selectLanguage": "Automatisch erkennen",
+          "selectLanguageHint": "Leer lassen für automatische Erkennung",
+          "selectLanguages": "Sprachen auswählen...",
+          "selectTranslate": "Sprachen auswählen...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Optionaler Text, um den Stil des Modells zu lenken oder ein vorheriges Segment fortzusetzen. Nicht unterstützt von gpt-4o-transcribe-diarize.",
+          "temperature": "Temperatur",
+          "temperatureDescription": "Höhere Werte erzeugen zufälligere Ergebnisse (0-1). Nur von whisper-1 unterstützt.",
+          "languageHints": "Sprachhinweise",
+          "languageHintsStrict": "Strikte Sprachhinweise",
+          "languageHintsStrictDescription": "Nur in den angegebenen Sprachen transkribieren",
+          "contextTerms": "Kontextbegriffe",
+          "contextTermsDescription": "Kommagetrennte Begriffe zur Verbesserung der Erkennungsgenauigkeit",
+          "contextDescription": "Kontextbeschreibung",
+          "contextDescriptionDescription": "Freitext mit allgemeinem Kontext zum Audioinhalt",
+          "enableSpeakerDiarization": "Sprechererkennung",
+          "enableSpeakerDiarizationDescription": "Verschiedene Sprecher identifizieren und trennen",
+          "enableLanguageIdentification": "Spracherkennung",
+          "enableLanguageIdentificationDescription": "Sprache für jedes Segment erkennen"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Lokale Modelle"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Keine Modelle konfiguriert. Besuche die Bibliothek, um Modelle herunterzuladen oder Cloud-Anbieter einzurichten."
       }
     },
     "general": {
@@ -259,18 +259,18 @@
         "descriptionUnsupported": "Das Parakeet-Modell erkennt die Sprache automatisch. Keine manuelle Auswahl erforderlich.",
         "searchPlaceholder": "Sprachen suchen...",
         "noResults": "Keine Sprachen gefunden",
-        "auto": "Auto"
+        "auto": "Automatisch"
       },
       "pushToTalk": {
         "label": "Push-to-Talk",
         "description": "Gedrückt halten zum Aufnehmen, loslassen zum Stoppen"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Tastenkürzel",
+        "strategyNone": "Keine",
+        "addNew": "Tastenkürzel hinzufügen",
+        "remove": "Tastenkürzel entfernen",
+        "postProcessNotReady": "Zuerst einen Nachbearbeitungsanbieter konfigurieren"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Ausgabe",
         "transcription": "Transkription",
         "history": "Verlauf",
-        "data": "Data",
+        "data": "Daten",
         "configuration": "Konfiguration"
       },
       "startHidden": {
@@ -390,38 +390,38 @@
         "duplicate": "\"{{word}}\" existiert bereits"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Daten exportieren",
+        "description": "Einstellungen, Verlauf und Aufnahmen in eine Datei exportieren",
+        "button": "Exportieren...",
+        "includeSettings": "Einstellungen",
+        "includeHistory": "Transkriptionsverlauf",
+        "includeRecordings": "Audioaufnahmen",
+        "success": "Daten erfolgreich exportiert",
+        "error": "Daten konnten nicht exportiert werden"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Daten importieren",
+        "description": "Einstellungen und Daten aus einer zuvor exportierten Datei importieren",
+        "button": "Importieren...",
+        "previewTitle": "Import-Vorschau",
+        "exportDate": "Exportiert am {{date}}",
+        "appVersion": "App-Version: {{version}}",
+        "historyCount": "{{count}} Verlaufseinträge",
+        "recordingsCount": "{{count}} Aufnahmen",
+        "statsCount": "{{count}} Sprechstatistiken",
+        "importSettings": "Einstellungen",
+        "importRecordings": "Aufnahmen",
+        "warning": "Das Importieren von Einstellungen überschreibt deine aktuelle Konfiguration. Die Exportdatei kann API Keys enthalten.",
+        "success": "Daten erfolgreich importiert",
+        "error": "Daten konnten nicht importiert werden",
+        "invalidFile": "Die ausgewählte Datei ist kein gültiger Handless-Export"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Design",
+        "description": "Farbthema der App auswählen",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
+          "dark": "Dunkel",
+          "light": "Hell",
           "system": "System"
         }
       },
@@ -526,8 +526,8 @@
       "unsave": "Aus Gespeicherten entfernen",
       "delete": "Eintrag löschen",
       "deleteError": "Eintrag konnte nicht gelöscht werden. Bitte versuche es erneut.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Original ausblenden",
+      "showOriginal": "Original anzeigen"
     },
     "debug": {
       "title": "Debug",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Sound-Thema",
         "description": "Sound-Thema für Aufnahme-Start und -Stop-Feedback auswählen",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Sound-Thema vorhören (spielt Start- und dann Stopp-Ton)"
       },
       "wordCorrectionThreshold": {
         "title": "Wortkorrektur-Schwelle",
@@ -659,8 +659,8 @@
     "yes": "Ja",
     "no": "Nein",
     "noOptionsFound": "Keine Optionen gefunden",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "In Zwischenablage kopieren",
+    "search": "Suchen..."
   },
   "accessibility": {
     "permissionsRequired": "Bedienungshilfen-Berechtigungen erforderlich",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Fast and accurate"
+        "description": "Fast and accurate. Supports 25 European languages."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -87,7 +87,7 @@
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Soniox cloud speech-to-text. High accuracy with realtime transcription."
       }
     },
     "errors": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Rápido y preciso"
+        "description": "Rápido y preciso. Compatible con 25 idiomas europeos."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "API de voz a texto en la nube de OpenAI. Rápida y precisa con soporte para más de 57 idiomas."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Voz a texto en la nube de Soniox. Alta precisión con transcripción en tiempo real."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Cancelar",
     "cancelDownload": "Cancelar descarga",
-    "notAvailable": "Not Available"
+    "notAvailable": "No Disponible"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Modelos descargados",
       "availableModels": "Disponibles para descargar",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Mis Modelos",
+        "library": "Biblioteca"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "Proveedores en la Nube",
+        "badge": "Nube",
+        "notConfigured": "No configurado",
+        "verify": "Verificar",
+        "verifying": "Verificando...",
+        "verified": "Verificado",
+        "verifyFailed": "La verificación falló",
+        "verifyFirst": "Verifica tu API Key primero",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Modelo",
+          "placeholder": "Ingresa el nombre del modelo"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Obtener API Key",
+        "realtimeTranscription": "Transcripción en tiempo real",
+        "realtimeDescription": "Usa una conexión WebSocket en lugar de carga de archivos para menor latencia",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Idioma",
+          "selectLanguage": "Detección automática",
+          "selectLanguageHint": "Deja vacío para detección automática",
+          "selectLanguages": "Seleccionar idiomas...",
+          "selectTranslate": "Seleccionar idiomas...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Texto opcional para guiar el estilo del modelo o continuar un segmento anterior. No compatible con gpt-4o-transcribe-diarize.",
+          "temperature": "Temperatura",
+          "temperatureDescription": "Valores más altos producen resultados más aleatorios (0-1). Solo compatible con whisper-1.",
+          "languageHints": "Sugerencias de Idioma",
+          "languageHintsStrict": "Sugerencias de Idioma Estrictas",
+          "languageHintsStrictDescription": "Solo transcribir en los idiomas especificados",
+          "contextTerms": "Términos de Contexto",
+          "contextTermsDescription": "Términos separados por comas para mejorar la precisión del reconocimiento",
+          "contextDescription": "Descripción del Contexto",
+          "contextDescriptionDescription": "Texto libre que proporciona contexto general sobre el contenido de audio",
+          "enableSpeakerDiarization": "Diarización de Hablantes",
+          "enableSpeakerDiarizationDescription": "Identificar y separar diferentes hablantes",
+          "enableLanguageIdentification": "Identificación de Idioma",
+          "enableLanguageIdentificationDescription": "Detectar el idioma de cada segmento"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Modelos Locales"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "No hay modelos configurados. Visita la Biblioteca para descargar modelos o configurar proveedores en la nube."
       }
     },
     "general": {
@@ -259,18 +259,18 @@
         "descriptionUnsupported": "El modelo Parakeet detecta automáticamente el idioma. No se necesita selección manual.",
         "searchPlaceholder": "Buscar idiomas...",
         "noResults": "No se encontraron idiomas",
-        "auto": "Auto"
+        "auto": "Automático"
       },
       "pushToTalk": {
         "label": "Presionar para Hablar",
         "description": "Mantén presionado para grabar, suelta para detener"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Atajos",
+        "strategyNone": "Ninguno",
+        "addNew": "Agregar Atajo",
+        "remove": "Eliminar atajo",
+        "postProcessNotReady": "Configura un proveedor de post procesamiento primero"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Salida",
         "transcription": "Transcripción",
         "history": "Historial",
-        "data": "Data",
+        "data": "Datos",
         "configuration": "Configuración"
       },
       "startHidden": {
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" ya existe"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Exportar Datos",
+        "description": "Exporta tu configuración, historial y grabaciones a un archivo",
+        "button": "Exportar...",
+        "includeSettings": "Configuración",
+        "includeHistory": "Historial de Transcripciones",
+        "includeRecordings": "Grabaciones de Audio",
+        "success": "Datos exportados correctamente",
+        "error": "Error al exportar los datos"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Importar Datos",
+        "description": "Importa configuración y datos desde un archivo exportado previamente",
+        "button": "Importar...",
+        "previewTitle": "Vista Previa de Importación",
+        "exportDate": "Exportado el {{date}}",
+        "appVersion": "Versión de la app: {{version}}",
+        "historyCount": "{{count}} entradas de historial",
+        "recordingsCount": "{{count}} grabaciones",
+        "statsCount": "{{count}} estadísticas de habla",
+        "importSettings": "Configuración",
+        "importRecordings": "Grabaciones",
+        "warning": "Importar la configuración sobrescribirá tu configuración actual. El archivo de exportación puede contener API Keys.",
+        "success": "Datos importados correctamente",
+        "error": "Error al importar los datos",
+        "invalidFile": "El archivo seleccionado no es una exportación válida de Handless"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Tema",
+        "description": "Elige el tema de color de la aplicación",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Oscuro",
+          "light": "Claro",
+          "system": "Sistema"
         }
       },
       "configFile": {
@@ -473,7 +473,7 @@
         "verified": "Verificado"
       },
       "prompts": {
-        "title": "Prompt",
+        "title": "Instrucción",
         "selectedPrompt": {
           "title": "Prompt Seleccionado",
           "description": "Selecciona una plantilla para refinar las transcripciones o crea una nueva. La transcripción capturada se proporciona automáticamente al prompt."
@@ -526,8 +526,8 @@
       "unsave": "Eliminar de guardados",
       "delete": "Eliminar entrada",
       "deleteError": "Error al eliminar la entrada. Por favor, intenta de nuevo.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Ocultar original",
+      "showOriginal": "Mostrar original"
     },
     "debug": {
       "title": "Depuración",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Tema de Sonido",
         "description": "Elige un tema de sonido para la retroalimentación de inicio y parada de grabación",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Previsualizar tema de sonido (reproduce inicio y luego parada)"
       },
       "wordCorrectionThreshold": {
         "title": "Umbral de Corrección de Palabras",
@@ -659,8 +659,8 @@
     "yes": "Sí",
     "no": "No",
     "noOptionsFound": "No se encontraron opciones",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Copiar al portapapeles",
+    "search": "Buscar..."
   },
   "accessibility": {
     "permissionsRequired": "Se Requieren Permisos de Accesibilidad",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Rapide et précis"
+        "description": "Rapide et précis. Prend en charge 25 langues européennes."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "API cloud de reconnaissance vocale d'OpenAI. Rapide et précise avec prise en charge de plus de 57 langues."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Reconnaissance vocale cloud Soniox. Haute précision avec transcription en temps réel."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Annuler",
     "cancelDownload": "Annuler le téléchargement",
-    "notAvailable": "Not Available"
+    "notAvailable": "Non disponible"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Modèles téléchargés",
       "availableModels": "Disponibles au téléchargement",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Mes modèles",
+        "library": "Bibliothèque"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
+        "title": "Fournisseurs cloud",
         "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "notConfigured": "Non configuré",
+        "verify": "Vérifier",
+        "verifying": "Vérification...",
+        "verified": "Vérifié",
+        "verifyFailed": "Échec de la vérification",
+        "verifyFirst": "Vérifiez d'abord votre clé API",
         "apiKey": {
-          "title": "API Key",
+          "title": "Clé API",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Modèle",
+          "placeholder": "Entrez le nom du modèle"
         },
         "baseUrl": {
-          "title": "Base URL"
+          "title": "URL de base"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Obtenir une clé API",
+        "realtimeTranscription": "Transcription en temps réel",
+        "realtimeDescription": "Utilise une connexion WebSocket au lieu d'un envoi de fichier pour une latence réduite",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Langue",
+          "selectLanguage": "Détection automatique",
+          "selectLanguageHint": "Laissez vide pour la détection automatique",
+          "selectLanguages": "Sélectionner les langues...",
+          "selectTranslate": "Sélectionner les langues...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Texte facultatif pour guider le style du modèle ou poursuivre un segment précédent. Non pris en charge par gpt-4o-transcribe-diarize.",
+          "temperature": "Température",
+          "temperatureDescription": "Des valeurs plus élevées produisent des résultats plus aléatoires (0-1). Pris en charge uniquement par whisper-1.",
+          "languageHints": "Indices de langue",
+          "languageHintsStrict": "Indices de langue stricts",
+          "languageHintsStrictDescription": "Transcrire uniquement dans les langues spécifiées",
+          "contextTerms": "Termes contextuels",
+          "contextTermsDescription": "Termes séparés par des virgules pour améliorer la précision de la reconnaissance",
+          "contextDescription": "Description du contexte",
+          "contextDescriptionDescription": "Texte libre fournissant un contexte général sur le contenu audio",
+          "enableSpeakerDiarization": "Diarisation des locuteurs",
+          "enableSpeakerDiarizationDescription": "Identifier et séparer les différents locuteurs",
+          "enableLanguageIdentification": "Identification de la langue",
+          "enableLanguageIdentificationDescription": "Détecter la langue pour chaque segment"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Modèles locaux"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Aucun modèle configuré. Visitez la Bibliothèque pour télécharger des modèles ou configurer des fournisseurs cloud."
       }
     },
     "general": {
@@ -259,18 +259,18 @@
         "descriptionUnsupported": "Le modèle Parakeet détecte automatiquement la langue. Aucune sélection manuelle n'est nécessaire.",
         "searchPlaceholder": "Rechercher des langues...",
         "noResults": "Aucune langue trouvée",
-        "auto": "Auto"
+        "auto": "Automatique"
       },
       "pushToTalk": {
         "label": "Appuyer pour parler",
         "description": "Maintenez pour enregistrer, relâchez pour arrêter"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Raccourcis",
+        "strategyNone": "Aucun",
+        "addNew": "Ajouter un raccourci",
+        "remove": "Supprimer le raccourci",
+        "postProcessNotReady": "Configurez d'abord un fournisseur de post-traitement"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Sortie",
         "transcription": "Transcription",
         "history": "Historique",
-        "data": "Data",
+        "data": "Données",
         "configuration": "Configuration"
       },
       "startHidden": {
@@ -330,7 +330,7 @@
           "clipboard": "Presse-papiers ({{modifier}}+V)",
           "clipboardCtrlShiftV": "Presse-papiers (Ctrl+Shift+V)",
           "clipboardShiftInsert": "Presse-papiers (Shift+Insert)",
-          "direct": "Direct",
+          "direct": "Directe",
           "none": "Aucun",
           "externalScript": "Script externe"
         },
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" existe déjà"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Exporter les données",
+        "description": "Exportez vos paramètres, votre historique et vos enregistrements dans un fichier",
+        "button": "Exporter...",
+        "includeSettings": "Paramètres",
+        "includeHistory": "Historique de transcription",
+        "includeRecordings": "Enregistrements audio",
+        "success": "Données exportées avec succès",
+        "error": "Échec de l'exportation des données"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Importer les données",
+        "description": "Importez des paramètres et des données à partir d'un fichier précédemment exporté",
+        "button": "Importer...",
+        "previewTitle": "Aperçu de l'importation",
+        "exportDate": "Exporté le {{date}}",
+        "appVersion": "Version de l'application : {{version}}",
+        "historyCount": "{{count}} entrées d'historique",
+        "recordingsCount": "{{count}} enregistrements",
+        "statsCount": "{{count}} statistiques de parole",
+        "importSettings": "Paramètres",
+        "importRecordings": "Enregistrements",
+        "warning": "L'importation des paramètres écrasera votre configuration actuelle. Le fichier d'exportation peut contenir des clés API.",
+        "success": "Données importées avec succès",
+        "error": "Échec de l'importation des données",
+        "invalidFile": "Le fichier sélectionné n'est pas une exportation Handless valide"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Thème",
+        "description": "Choisissez le thème de couleur de l'application",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Sombre",
+          "light": "Clair",
+          "system": "Système"
         }
       },
       "configFile": {
@@ -473,7 +473,7 @@
         "verified": "Vérifié"
       },
       "prompts": {
-        "title": "Prompt",
+        "title": "Consigne",
         "selectedPrompt": {
           "title": "Prompt sélectionné",
           "description": "Sélectionnez un modèle pour affiner les transcriptions ou créez-en un nouveau. La transcription capturée est automatiquement fournie au prompt."
@@ -526,8 +526,8 @@
       "unsave": "Retirer des favoris",
       "delete": "Supprimer l'entrée",
       "deleteError": "Échec de la suppression de l'entrée. Veuillez réessayer.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Masquer l'original",
+      "showOriginal": "Afficher l'original"
     },
     "debug": {
       "title": "Débogage",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Thème sonore",
         "description": "Choisir un thème sonore pour les retours de début et de fin d'enregistrement",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Aperçu du thème sonore (joue le son de début puis de fin)"
       },
       "wordCorrectionThreshold": {
         "title": "Seuil de correction des mots",
@@ -659,8 +659,8 @@
     "yes": "Oui",
     "no": "Non",
     "noOptionsFound": "Aucune option trouvée",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Copier dans le presse-papiers",
+    "search": "Rechercher..."
   },
   "accessibility": {
     "permissionsRequired": "Autorisations d'accessibilité requises",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Veloce e accurato"
+        "description": "Veloce e accurato. Supporta 25 lingue europee."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "API cloud di riconoscimento vocale di OpenAI. Veloce e precisa con supporto per oltre 57 lingue."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Riconoscimento vocale cloud Soniox. Alta precisione con trascrizione in tempo reale."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Annulla",
     "cancelDownload": "Annulla download",
-    "notAvailable": "Not Available"
+    "notAvailable": "Non disponibile"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Modelli scaricati",
       "availableModels": "Disponibili per il download",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "I miei modelli",
+        "library": "Libreria"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
+        "title": "Fornitori cloud",
         "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "notConfigured": "Non configurato",
+        "verify": "Verifica",
+        "verifying": "Verifica in corso...",
+        "verified": "Verificato",
+        "verifyFailed": "Verifica fallita",
+        "verifyFirst": "Verifica prima la tua chiave API",
         "apiKey": {
-          "title": "API Key",
+          "title": "Chiave API",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Modello",
+          "placeholder": "Inserisci il nome del modello"
         },
         "baseUrl": {
-          "title": "Base URL"
+          "title": "URL Base"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Ottieni chiave API",
+        "realtimeTranscription": "Trascrizione in tempo reale",
+        "realtimeDescription": "Usa una connessione WebSocket invece dell'invio di file per una latenza ridotta",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Lingua",
+          "selectLanguage": "Rilevamento automatico",
+          "selectLanguageHint": "Lascia vuoto per il rilevamento automatico",
+          "selectLanguages": "Seleziona lingue...",
+          "selectTranslate": "Seleziona lingue...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Testo facoltativo per guidare lo stile del modello o continuare un segmento precedente. Non supportato da gpt-4o-transcribe-diarize.",
+          "temperature": "Temperatura",
+          "temperatureDescription": "Valori più alti producono risultati più casuali (0-1). Supportato solo da whisper-1.",
+          "languageHints": "Suggerimenti lingua",
+          "languageHintsStrict": "Suggerimenti lingua rigorosi",
+          "languageHintsStrictDescription": "Trascrivi solo nelle lingue specificate",
+          "contextTerms": "Termini contestuali",
+          "contextTermsDescription": "Termini separati da virgola per migliorare la precisione del riconoscimento",
+          "contextDescription": "Descrizione del contesto",
+          "contextDescriptionDescription": "Testo libero che fornisce un contesto generale sul contenuto audio",
+          "enableSpeakerDiarization": "Diarizzazione dei parlanti",
+          "enableSpeakerDiarizationDescription": "Identifica e separa i diversi parlanti",
+          "enableLanguageIdentification": "Identificazione della lingua",
+          "enableLanguageIdentificationDescription": "Rileva la lingua per ogni segmento"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Modelli locali"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Nessun modello configurato. Visita la Libreria per scaricare modelli o configurare fornitori cloud."
       }
     },
     "general": {
@@ -259,18 +259,18 @@
         "descriptionUnsupported": "Il modello Parakeet sceglie automaticamente la lingua. Non serve scegliere manualmente.",
         "searchPlaceholder": "Cerca lingue...",
         "noResults": "Nessuna lingua trovata",
-        "auto": "Auto"
+        "auto": "Automatico"
       },
       "pushToTalk": {
         "label": "Premi per Parlare",
         "description": "Tieni premuto per parlare, rilascia per interrompere"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Scorciatoie",
+        "strategyNone": "Nessuna",
+        "addNew": "Aggiungi scorciatoia",
+        "remove": "Rimuovi scorciatoia",
+        "postProcessNotReady": "Configura prima un fornitore di post-elaborazione"
       }
     },
     "sound": {
@@ -295,11 +295,11 @@
     "advanced": {
       "title": "Avanzate",
       "groups": {
-        "app": "App",
+        "app": "Applicazione",
         "output": "Output",
         "transcription": "Trascrizione",
         "history": "Cronologia",
-        "data": "Data",
+        "data": "Dati",
         "configuration": "Configurazione"
       },
       "startHidden": {
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" esiste già"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Esporta dati",
+        "description": "Esporta le impostazioni, la cronologia e le registrazioni in un file",
+        "button": "Esporta...",
+        "includeSettings": "Impostazioni",
+        "includeHistory": "Cronologia trascrizioni",
+        "includeRecordings": "Registrazioni audio",
+        "success": "Dati esportati con successo",
+        "error": "Errore nell'esportazione dei dati"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Importa dati",
+        "description": "Importa impostazioni e dati da un file precedentemente esportato",
+        "button": "Importa...",
+        "previewTitle": "Anteprima importazione",
+        "exportDate": "Esportato il {{date}}",
+        "appVersion": "Versione app: {{version}}",
+        "historyCount": "{{count}} voci di cronologia",
+        "recordingsCount": "{{count}} registrazioni",
+        "statsCount": "{{count}} statistiche di parlato",
+        "importSettings": "Impostazioni",
+        "importRecordings": "Registrazioni",
+        "warning": "L'importazione delle impostazioni sovrascriverà la configurazione attuale. Il file di esportazione potrebbe contenere chiavi API.",
+        "success": "Dati importati con successo",
+        "error": "Errore nell'importazione dei dati",
+        "invalidFile": "Il file selezionato non è un'esportazione Handless valida"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Tema",
+        "description": "Scegli il tema colore dell'applicazione",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Scuro",
+          "light": "Chiaro",
+          "system": "Sistema"
         }
       },
       "configFile": {
@@ -441,8 +441,8 @@
       "api": {
         "title": "API (Compatibile con OpenAI)",
         "provider": {
-          "title": "Provider",
-          "description": "Seleziona un provider compatibile con OpenAI."
+          "title": "Fornitore",
+          "description": "Seleziona un fornitore compatibile con OpenAI."
         },
         "appleIntelligence": {
           "title": "Apple Intelligence",
@@ -473,7 +473,7 @@
         "verified": "Verificato"
       },
       "prompts": {
-        "title": "Prompt",
+        "title": "Istruzione",
         "selectedPrompt": {
           "title": "Prompt Selezionato",
           "description": "Seleziona un template per migliorare le trascrizioni o creane uno nuovo. La trascrizione catturata viene fornita automaticamente al prompt."
@@ -526,8 +526,8 @@
       "unsave": "Rimuovi dai salvataggi",
       "delete": "Elimina elemento",
       "deleteError": "Errore nell'eliminazione dell'elemento. Per favore, prova di nuovo.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Nascondi originale",
+      "showOriginal": "Mostra originale"
     },
     "debug": {
       "title": "Debug",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Tema Sonoro",
         "description": "Scegli un tema sonoro per il feedback di inizio e fine registrazione",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Anteprima del tema sonoro (riproduce inizio e poi fine)"
       },
       "wordCorrectionThreshold": {
         "title": "Soglia di Correzione Parole",
@@ -651,16 +651,16 @@
     "update": "Aggiorna",
     "close": "Chiudi",
     "open": "Apri",
-    "default": "Default",
+    "default": "Predefinito",
     "enabled": "Abilitato",
     "disabled": "Disabilitato",
-    "on": "On",
-    "off": "Off",
+    "on": "Attivo",
+    "off": "Disattivo",
     "yes": "Sì",
     "no": "No",
     "noOptionsFound": "Nessuna opzione trovata",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Copia negli appunti",
+    "search": "Cerca..."
   },
   "accessibility": {
     "permissionsRequired": "Richiesti Permessi di Accessibilità",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "高速で正確"
+        "description": "高速で正確。25のヨーロッパ言語に対応。"
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "OpenAIのクラウド音声テキスト変換API。高速・高精度で57以上の言語に対応。"
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Sonioxクラウド音声テキスト変換。リアルタイム文字起こしによる高精度。"
       }
     }
   },
@@ -132,7 +132,7 @@
     "modelUnloaded": "モデルがアンロードされました",
     "noModelDownloadRequired": "モデルなし - ダウンロードが必要",
     "deleteModel": "{{modelName}}を削除",
-    "downloadSpeed": "{{speed}} MB/s",
+    "downloadSpeed": "{{speed}} MB/秒",
     "capabilities": {
       "languageSelection": "複数の入力言語をサポート",
       "multiLanguage": "多言語",
@@ -143,7 +143,7 @@
     },
     "cancel": "キャンセル",
     "cancelDownload": "ダウンロードをキャンセル",
-    "notAvailable": "Not Available"
+    "notAvailable": "利用不可"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "ダウンロード済みモデル",
       "availableModels": "ダウンロード可能",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "マイモデル",
+        "library": "ライブラリ"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "クラウドプロバイダー",
+        "badge": "クラウド",
+        "notConfigured": "未設定",
+        "verify": "検証",
+        "verifying": "検証中...",
+        "verified": "検証済み",
+        "verifyFailed": "検証に失敗しました",
+        "verifyFirst": "先にAPI Keyを検証してください",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "モデル",
+          "placeholder": "モデル名を入力"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "API Keyを取得",
+        "realtimeTranscription": "リアルタイム文字起こし",
+        "realtimeDescription": "低遅延のためにファイルアップロードの代わりにWebSocket接続を使用",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
-          "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "language": "言語",
+          "selectLanguage": "自動検出",
+          "selectLanguageHint": "空欄のままにすると自動検出します",
+          "selectLanguages": "言語を選択...",
+          "selectTranslate": "言語を選択...",
+          "prompt": "プロンプト",
+          "promptDescription": "モデルのスタイルを指示したり、前のセグメントを継続するためのオプションテキスト。gpt-4o-transcribe-diarizeでは非対応。",
+          "temperature": "温度",
+          "temperatureDescription": "値が高いほどランダムな結果になります（0-1）。whisper-1のみ対応。",
+          "languageHints": "言語ヒント",
+          "languageHintsStrict": "厳密な言語ヒント",
+          "languageHintsStrictDescription": "指定した言語のみで文字起こし",
+          "contextTerms": "コンテキスト用語",
+          "contextTermsDescription": "認識精度を向上させるためのカンマ区切りの用語",
+          "contextDescription": "コンテキスト説明",
+          "contextDescriptionDescription": "音声コンテンツの一般的なコンテキストを提供する自由形式のテキスト",
+          "enableSpeakerDiarization": "話者分離",
+          "enableSpeakerDiarizationDescription": "異なる話者を識別して分離",
+          "enableLanguageIdentification": "言語識別",
+          "enableLanguageIdentificationDescription": "各セグメントの言語を検出"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "ローカルモデル"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "モデルが設定されていません。ライブラリからモデルをダウンロードするか、クラウドプロバイダーを設定してください。"
       }
     },
     "general": {
@@ -266,11 +266,11 @@
         "description": "押し続けて録音、離して停止"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "ショートカット",
+        "strategyNone": "なし",
+        "addNew": "ショートカットを追加",
+        "remove": "ショートカットを削除",
+        "postProcessNotReady": "先に後処理プロバイダーを設定してください"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "出力",
         "transcription": "文字起こし",
         "history": "履歴",
-        "data": "Data",
+        "data": "データ",
         "configuration": "設定ファイル"
       },
       "startHidden": {
@@ -334,7 +334,7 @@
           "none": "なし",
           "externalScript": "外部スクリプト"
         },
-        "externalScriptPlaceholder": "/path/to/your/script.sh"
+        "externalScriptPlaceholder": "/スクリプトへの/パス.sh"
       },
       "typingTool": {
         "title": "タイピングツール",
@@ -390,39 +390,39 @@
         "duplicate": "「{{word}}」は既に存在します"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "データのエクスポート",
+        "description": "設定、履歴、録音をファイルにエクスポート",
+        "button": "エクスポート...",
+        "includeSettings": "設定",
+        "includeHistory": "文字起こし履歴",
+        "includeRecordings": "音声録音",
+        "success": "データのエクスポートに成功しました",
+        "error": "データのエクスポートに失敗しました"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "データのインポート",
+        "description": "以前にエクスポートしたファイルから設定とデータをインポート",
+        "button": "インポート...",
+        "previewTitle": "インポートプレビュー",
+        "exportDate": "{{date}}にエクスポート",
+        "appVersion": "アプリバージョン: {{version}}",
+        "historyCount": "{{count}}件の履歴エントリー",
+        "recordingsCount": "{{count}}件の録音",
+        "statsCount": "{{count}}件の発話統計",
+        "importSettings": "設定",
+        "importRecordings": "録音",
+        "warning": "設定をインポートすると現在の設定が上書きされます。エクスポートファイルにはAPI Keyが含まれている場合があります。",
+        "success": "データのインポートに成功しました",
+        "error": "データのインポートに失敗しました",
+        "invalidFile": "選択したファイルは有効なHandlessエクスポートではありません"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "テーマ",
+        "description": "アプリのカラーテーマを選択",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "ダーク",
+          "light": "ライト",
+          "system": "システム"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "保存から削除",
       "delete": "エントリーを削除",
       "deleteError": "エントリーの削除に失敗しました。もう一度お試しください。",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "原文を非表示",
+      "showOriginal": "原文を表示"
     },
     "debug": {
       "title": "デバッグ",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "サウンドテーマ",
         "description": "録音開始・停止フィードバックのサウンドテーマを選択",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "サウンドテーマをプレビュー（開始音と停止音を再生）"
       },
       "wordCorrectionThreshold": {
         "title": "単語修正しきい値",
@@ -659,8 +659,8 @@
     "yes": "はい",
     "no": "いいえ",
     "noOptionsFound": "オプションが見つかりません",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "クリップボードにコピー",
+    "search": "検索..."
   },
   "accessibility": {
     "permissionsRequired": "アクセシビリティ権限が必要です",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "빠르고 정확함"
+        "description": "빠르고 정확함. 25개 유럽 언어 지원."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "OpenAI 클라우드 음성-텍스트 변환 API. 빠르고 정확하며 57개 이상의 언어를 지원합니다."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Soniox 클라우드 음성-텍스트 변환. 실시간 전사로 높은 정확도를 제공합니다."
       }
     }
   },
@@ -132,7 +132,7 @@
     "modelUnloaded": "모델 언로드됨",
     "noModelDownloadRequired": "모델 없음 - 다운로드 필요",
     "deleteModel": "{{modelName}} 삭제",
-    "downloadSpeed": "{{speed}} MB/s",
+    "downloadSpeed": "{{speed}} MB/초",
     "cancel": "취소",
     "cancelDownload": "다운로드 취소",
     "capabilities": {
@@ -143,7 +143,7 @@
       "translation": "영어로 번역 가능",
       "translate": "영어로 번역"
     },
-    "notAvailable": "Not Available"
+    "notAvailable": "사용 불가"
   },
   "settings": {
     "modelSettings": {
@@ -192,11 +192,11 @@
         "description": "누르고 있으면 녹음, 놓으면 정지"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "단축키",
+        "strategyNone": "없음",
+        "addNew": "단축키 추가",
+        "remove": "단축키 제거",
+        "postProcessNotReady": "먼저 후처리 제공자를 설정하세요"
       }
     },
     "sound": {
@@ -236,60 +236,60 @@
       },
       "noModelsMatch": "이 필터에 맞는 모델이 없습니다.",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "내 모델",
+        "library": "라이브러리"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "클라우드 제공자",
+        "badge": "클라우드",
+        "notConfigured": "미설정",
+        "verify": "검증",
+        "verifying": "검증 중...",
+        "verified": "검증됨",
+        "verifyFailed": "검증 실패",
+        "verifyFirst": "먼저 API Key를 검증하세요",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "모델",
+          "placeholder": "모델 이름 입력"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "API Key 받기",
+        "realtimeTranscription": "실시간 전사",
+        "realtimeDescription": "낮은 지연 시간을 위해 파일 업로드 대신 WebSocket 연결을 사용",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
-          "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "language": "언어",
+          "selectLanguage": "자동 감지",
+          "selectLanguageHint": "비워두면 자동으로 감지합니다",
+          "selectLanguages": "언어 선택...",
+          "selectTranslate": "언어 선택...",
+          "prompt": "프롬프트",
+          "promptDescription": "모델의 스타일을 안내하거나 이전 세그먼트를 계속하기 위한 선택적 텍스트. gpt-4o-transcribe-diarize에서는 지원되지 않습니다.",
+          "temperature": "온도",
+          "temperatureDescription": "높은 값은 더 무작위적인 결과를 생성합니다 (0-1). whisper-1에서만 지원됩니다.",
+          "languageHints": "언어 힌트",
+          "languageHintsStrict": "엄격한 언어 힌트",
+          "languageHintsStrictDescription": "지정된 언어로만 전사",
+          "contextTerms": "컨텍스트 용어",
+          "contextTermsDescription": "인식 정확도를 향상시키기 위한 쉼표로 구분된 용어",
+          "contextDescription": "컨텍스트 설명",
+          "contextDescriptionDescription": "오디오 콘텐츠에 대한 일반적인 컨텍스트를 제공하는 자유 형식 텍스트",
+          "enableSpeakerDiarization": "화자 분리",
+          "enableSpeakerDiarizationDescription": "서로 다른 화자를 식별하고 분리",
+          "enableLanguageIdentification": "언어 식별",
+          "enableLanguageIdentificationDescription": "각 세그먼트의 언어를 감지"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "로컬 모델"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "설정된 모델이 없습니다. 라이브러리에서 모델을 다운로드하거나 클라우드 제공자를 설정하세요."
       }
     },
     "advanced": {
@@ -299,7 +299,7 @@
         "output": "출력",
         "transcription": "전사",
         "history": "히스토리",
-        "data": "Data",
+        "data": "데이터",
         "configuration": "구성"
       },
       "startHidden": {
@@ -334,7 +334,7 @@
           "none": "없음",
           "externalScript": "외부 스크립트"
         },
-        "externalScriptPlaceholder": "/path/to/your/script.sh"
+        "externalScriptPlaceholder": "/스크립트/경로.sh"
       },
       "typingTool": {
         "title": "타이핑 도구",
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\"이(가) 이미 존재합니다"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "데이터 내보내기",
+        "description": "설정, 히스토리, 녹음을 파일로 내보내기",
+        "button": "내보내기...",
+        "includeSettings": "설정",
+        "includeHistory": "전사 히스토리",
+        "includeRecordings": "오디오 녹음",
+        "success": "데이터를 성공적으로 내보냈습니다",
+        "error": "데이터 내보내기에 실패했습니다"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "데이터 가져오기",
+        "description": "이전에 내보낸 파일에서 설정 및 데이터 가져오기",
+        "button": "가져오기...",
+        "previewTitle": "가져오기 미리보기",
+        "exportDate": "{{date}}에 내보냄",
+        "appVersion": "앱 버전: {{version}}",
+        "historyCount": "{{count}}개의 히스토리 항목",
+        "recordingsCount": "{{count}}개의 녹음",
+        "statsCount": "{{count}}개의 발화 통계",
+        "importSettings": "설정",
+        "importRecordings": "녹음",
+        "warning": "설정을 가져오면 현재 구성이 덮어쓰기됩니다. 내보내기 파일에 API Key가 포함되어 있을 수 있습니다.",
+        "success": "데이터를 성공적으로 가져왔습니다",
+        "error": "데이터 가져오기에 실패했습니다",
+        "invalidFile": "선택한 파일은 유효한 Handless 내보내기 파일이 아닙니다"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "테마",
+        "description": "앱 색상 테마를 선택",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "다크",
+          "light": "라이트",
+          "system": "시스템"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "저장에서 제거",
       "delete": "항목 삭제",
       "deleteError": "항목 삭제에 실패했습니다. 다시 시도해주세요.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "원본 숨기기",
+      "showOriginal": "원본 보기"
     },
     "debug": {
       "title": "디버그",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "사운드 테마",
         "description": "녹음 시작 및 정지 피드백을 위한 사운드 테마를 선택하세요",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "사운드 테마 미리듣기 (시작음과 정지음 재생)"
       },
       "wordCorrectionThreshold": {
         "title": "단어 수정 임계값",
@@ -659,8 +659,8 @@
     "yes": "예",
     "no": "아니오",
     "noOptionsFound": "옵션을 찾을 수 없습니다",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "클립보드에 복사",
+    "search": "검색..."
   },
   "accessibility": {
     "permissionsRequired": "접근성 권한 필요",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Szybki i dokładny"
+        "description": "Szybki i dokładny. Obsługuje 25 języków europejskich."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "Chmurowe API zamiany mowy na tekst od OpenAI. Szybkie i dokładne z obsługą ponad 57 języków."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Chmurowa zamiana mowy na tekst Soniox. Wysoka dokładność z transkrypcją w czasie rzeczywistym."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Anuluj",
     "cancelDownload": "Anuluj pobieranie",
-    "notAvailable": "Not Available"
+    "notAvailable": "Niedostępny"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Pobrane modele",
       "availableModels": "Dostępne do pobrania",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Moje modele",
+        "library": "Biblioteka"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
+        "title": "Dostawcy chmurowi",
         "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "notConfigured": "Nieskonfigurowany",
+        "verify": "Zweryfikuj",
+        "verifying": "Weryfikowanie...",
+        "verified": "Zweryfikowano",
+        "verifyFailed": "Weryfikacja nieudana",
+        "verifyFirst": "Najpierw zweryfikuj swój klucz API",
         "apiKey": {
-          "title": "API Key",
+          "title": "Klucz API",
           "placeholder": "sk-..."
         },
         "model": {
           "title": "Model",
-          "placeholder": "Enter model name"
+          "placeholder": "Wpisz nazwę modelu"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Uzyskaj klucz API",
+        "realtimeTranscription": "Transkrypcja w czasie rzeczywistym",
+        "realtimeDescription": "Używa połączenia WebSocket zamiast przesyłania pliku w celu zmniejszenia opóźnienia",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Język",
+          "selectLanguage": "Automatyczne wykrywanie",
+          "selectLanguageHint": "Pozostaw puste, aby wykryć automatycznie",
+          "selectLanguages": "Wybierz języki...",
+          "selectTranslate": "Wybierz języki...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Opcjonalny tekst służący do kierowania stylem modelu lub kontynuowania poprzedniego segmentu. Nieobsługiwane przez gpt-4o-transcribe-diarize.",
+          "temperature": "Temperatura",
+          "temperatureDescription": "Wyższe wartości dają bardziej losowe wyniki (0–1). Obsługiwane tylko przez whisper-1.",
+          "languageHints": "Wskazówki językowe",
+          "languageHintsStrict": "Ścisłe wskazówki językowe",
+          "languageHintsStrictDescription": "Transkrybuj tylko w podanych językach",
+          "contextTerms": "Terminy kontekstowe",
+          "contextTermsDescription": "Terminy oddzielone przecinkami w celu poprawy dokładności rozpoznawania",
+          "contextDescription": "Opis kontekstu",
+          "contextDescriptionDescription": "Dowolny tekst opisujący ogólny kontekst treści audio",
+          "enableSpeakerDiarization": "Diaryzacja mówców",
+          "enableSpeakerDiarizationDescription": "Identyfikuj i oddzielaj różnych mówców",
+          "enableLanguageIdentification": "Identyfikacja języka",
+          "enableLanguageIdentificationDescription": "Wykrywaj język dla każdego segmentu"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Modele lokalne"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Brak skonfigurowanych modeli. Odwiedź Bibliotekę, aby pobrać modele lub skonfigurować dostawców chmurowych."
       }
     },
     "general": {
@@ -259,18 +259,18 @@
         "descriptionUnsupported": "Model Parakeet automatycznie wykrywa język. Nie jest potrzebny ręczny wybór.",
         "searchPlaceholder": "Szukaj języka...",
         "noResults": "Nie znaleziono języków",
-        "auto": "Auto"
+        "auto": "Automatycznie"
       },
       "pushToTalk": {
-        "label": "Push To Talk",
+        "label": "Naciśnij i mów",
         "description": "Przytrzymaj, aby nagrywać, puść, aby zatrzymać"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Skróty",
+        "strategyNone": "Brak",
+        "addNew": "Dodaj skrót",
+        "remove": "Usuń skrót",
+        "postProcessNotReady": "Najpierw skonfiguruj dostawcę postprocessingu"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Wyjście",
         "transcription": "Transkrypcja",
         "history": "Historia",
-        "data": "Data",
+        "data": "Dane",
         "configuration": "Konfiguracja"
       },
       "startHidden": {
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" już istnieje"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Eksport danych",
+        "description": "Eksportuj ustawienia, historię i nagrania do pliku",
+        "button": "Eksportuj...",
+        "includeSettings": "Ustawienia",
+        "includeHistory": "Historia transkrypcji",
+        "includeRecordings": "Nagrania audio",
+        "success": "Dane wyeksportowane pomyślnie",
+        "error": "Nie udało się wyeksportować danych"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Import danych",
+        "description": "Importuj ustawienia i dane z wcześniej wyeksportowanego pliku",
+        "button": "Importuj...",
+        "previewTitle": "Podgląd importu",
+        "exportDate": "Wyeksportowano dnia {{date}}",
+        "appVersion": "Wersja aplikacji: {{version}}",
+        "historyCount": "{{count}} wpisów historii",
+        "recordingsCount": "{{count}} nagrań",
+        "statsCount": "{{count}} statystyk mowy",
+        "importSettings": "Ustawienia",
+        "importRecordings": "Nagrania",
+        "warning": "Import ustawień nadpisze bieżącą konfigurację. Plik eksportu może zawierać klucze API.",
+        "success": "Dane zaimportowane pomyślnie",
+        "error": "Nie udało się zaimportować danych",
+        "invalidFile": "Wybrany plik nie jest prawidłowym eksportem Handless"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Motyw",
+        "description": "Wybierz motyw kolorystyczny aplikacji",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Ciemny",
+          "light": "Jasny",
+          "system": "Systemowy"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "Usuń z zapisanych",
       "delete": "Usuń wpis",
       "deleteError": "Nie udało się usunąć wpisu. Spróbuj ponownie.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Ukryj oryginał",
+      "showOriginal": "Pokaż oryginał"
     },
     "debug": {
       "title": "Debugowanie",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Motyw dźwiękowy",
         "description": "Wybierz motyw dźwiękowy dla informacji o rozpoczęciu i zakończeniu nagrywania",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Odtwórz podgląd motywu dźwiękowego (odtwarza start, potem stop)"
       },
       "wordCorrectionThreshold": {
         "title": "Próg korekty słów",
@@ -659,8 +659,8 @@
     "yes": "Tak",
     "no": "Nie",
     "noOptionsFound": "Nie znaleziono opcji",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Kopiuj do schowka",
+    "search": "Szukaj..."
   },
   "accessibility": {
     "permissionsRequired": "Wymagane uprawnienia dostępności",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Rápido e preciso"
+        "description": "Rápido e preciso. Suporta 25 idiomas europeus."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "API de voz para texto na nuvem da OpenAI. Rápida e precisa com suporte para mais de 57 idiomas."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Voz para texto na nuvem da Soniox. Alta precisão com transcrição em tempo real."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Cancelar",
     "cancelDownload": "Cancelar download",
-    "notAvailable": "Not Available"
+    "notAvailable": "Não Disponível"
   },
   "settings": {
     "modelSettings": {
@@ -185,18 +185,18 @@
         "descriptionUnsupported": "O modelo Parakeet detecta automaticamente o idioma. Não é necessária seleção manual.",
         "searchPlaceholder": "Buscar idiomas...",
         "noResults": "Nenhum idioma encontrado",
-        "auto": "Auto"
+        "auto": "Automático"
       },
       "pushToTalk": {
         "label": "Pressionar para Falar",
         "description": "Segure para gravar, solte para parar"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Atalhos",
+        "strategyNone": "Nenhum",
+        "addNew": "Adicionar Atalho",
+        "remove": "Remover atalho",
+        "postProcessNotReady": "Configure um provedor de pós-processamento primeiro"
       }
     },
     "models": {
@@ -217,60 +217,60 @@
       "yourModels": "Modelos baixados",
       "availableModels": "Disponíveis para download",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Meus Modelos",
+        "library": "Biblioteca"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "Provedores na Nuvem",
+        "badge": "Nuvem",
+        "notConfigured": "Não configurado",
+        "verify": "Verificar",
+        "verifying": "Verificando...",
+        "verified": "Verificado",
+        "verifyFailed": "Falha na verificação",
+        "verifyFirst": "Verifique sua API Key primeiro",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Modelo",
+          "placeholder": "Digite o nome do modelo"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Obter API Key",
+        "realtimeTranscription": "Transcrição em tempo real",
+        "realtimeDescription": "Usa uma conexão WebSocket em vez de upload de arquivo para menor latência",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Idioma",
+          "selectLanguage": "Detecção automática",
+          "selectLanguageHint": "Deixe vazio para detecção automática",
+          "selectLanguages": "Selecionar idiomas...",
+          "selectTranslate": "Selecionar idiomas...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Texto opcional para guiar o estilo do modelo ou continuar um segmento anterior. Não compatível com gpt-4o-transcribe-diarize.",
+          "temperature": "Temperatura",
+          "temperatureDescription": "Valores mais altos produzem resultados mais aleatórios (0-1). Apenas compatível com whisper-1.",
+          "languageHints": "Sugestões de Idioma",
+          "languageHintsStrict": "Sugestões de Idioma Estritas",
+          "languageHintsStrictDescription": "Transcrever apenas nos idiomas especificados",
+          "contextTerms": "Termos de Contexto",
+          "contextTermsDescription": "Termos separados por vírgula para melhorar a precisão do reconhecimento",
+          "contextDescription": "Descrição do Contexto",
+          "contextDescriptionDescription": "Texto livre fornecendo contexto geral sobre o conteúdo de áudio",
+          "enableSpeakerDiarization": "Diarização de Falantes",
+          "enableSpeakerDiarizationDescription": "Identificar e separar diferentes falantes",
+          "enableLanguageIdentification": "Identificação de Idioma",
+          "enableLanguageIdentificationDescription": "Detectar o idioma de cada segmento"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Modelos Locais"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Nenhum modelo configurado. Visite a Biblioteca para baixar modelos ou configurar provedores na nuvem."
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Saída",
         "transcription": "Transcrição",
         "history": "Histórico",
-        "data": "Data",
+        "data": "Dados",
         "configuration": "Configuração"
       },
       "startHidden": {
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" já existe"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Exportar Dados",
+        "description": "Exporte suas configurações, histórico e gravações para um arquivo",
+        "button": "Exportar...",
+        "includeSettings": "Configurações",
+        "includeHistory": "Histórico de Transcrições",
+        "includeRecordings": "Gravações de Áudio",
+        "success": "Dados exportados com sucesso",
+        "error": "Falha ao exportar dados"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Importar Dados",
+        "description": "Importe configurações e dados de um arquivo exportado anteriormente",
+        "button": "Importar...",
+        "previewTitle": "Pré-visualização da Importação",
+        "exportDate": "Exportado em {{date}}",
+        "appVersion": "Versão do app: {{version}}",
+        "historyCount": "{{count}} entradas de histórico",
+        "recordingsCount": "{{count}} gravações",
+        "statsCount": "{{count}} estatísticas de fala",
+        "importSettings": "Configurações",
+        "importRecordings": "Gravações",
+        "warning": "Importar configurações sobrescreverá sua configuração atual. O arquivo de exportação pode conter API Keys.",
+        "success": "Dados importados com sucesso",
+        "error": "Falha ao importar dados",
+        "invalidFile": "O arquivo selecionado não é uma exportação válida do Handless"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Tema",
+        "description": "Escolha o tema de cor do aplicativo",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Escuro",
+          "light": "Claro",
+          "system": "Sistema"
         }
       },
       "configFile": {
@@ -473,7 +473,7 @@
         "verified": "Verificado"
       },
       "prompts": {
-        "title": "Prompt",
+        "title": "Instrução",
         "selectedPrompt": {
           "title": "Prompt Selecionado",
           "description": "Selecione um modelo para refinar transcrições ou crie um novo. A transcrição capturada é fornecida automaticamente ao prompt."
@@ -526,8 +526,8 @@
       "unsave": "Remover dos salvos",
       "delete": "Excluir entrada",
       "deleteError": "Falha ao excluir entrada. Por favor, tente novamente.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Ocultar original",
+      "showOriginal": "Mostrar original"
     },
     "debug": {
       "title": "Depuração",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Tema de Som",
         "description": "Escolha um tema de som para feedback de início e parada de gravação",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Pré-visualizar tema de som (reproduz início e depois parada)"
       },
       "wordCorrectionThreshold": {
         "title": "Limite de Correção de Palavras",
@@ -659,8 +659,8 @@
     "yes": "Sim",
     "no": "Não",
     "noOptionsFound": "Nenhuma opção encontrada",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Copiar para área de transferência",
+    "search": "Buscar..."
   },
   "accessibility": {
     "permissionsRequired": "Permissões de Acessibilidade Necessárias",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Быстро и точно"
+        "description": "Быстро и точно. Поддерживает 25 европейских языков."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "Облачный API распознавания речи OpenAI. Быстрый и точный с поддержкой 57+ языков."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Облачное распознавание речи Soniox. Высокая точность с транскрипцией в реальном времени."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Отмена",
     "cancelDownload": "Отменить загрузку",
-    "notAvailable": "Not Available"
+    "notAvailable": "Недоступно"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Загруженные модели",
       "availableModels": "Доступны для загрузки",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Мои модели",
+        "library": "Библиотека"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "Облачные провайдеры",
+        "badge": "Облако",
+        "notConfigured": "Не настроен",
+        "verify": "Проверить",
+        "verifying": "Проверка...",
+        "verified": "Проверено",
+        "verifyFailed": "Проверка не удалась",
+        "verifyFirst": "Сначала проверьте ваш API Key",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Модель",
+          "placeholder": "Введите название модели"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Получить API Key",
+        "realtimeTranscription": "Транскрипция в реальном времени",
+        "realtimeDescription": "Использует WebSocket-соединение вместо загрузки файла для снижения задержки",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
-          "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "language": "Язык",
+          "selectLanguage": "Автоопределение",
+          "selectLanguageHint": "Оставьте пустым для автоопределения",
+          "selectLanguages": "Выберите языки...",
+          "selectTranslate": "Выберите языки...",
+          "prompt": "Промпт",
+          "promptDescription": "Необязательный текст для управления стилем модели или продолжения предыдущего сегмента. Не поддерживается gpt-4o-transcribe-diarize.",
+          "temperature": "Температура",
+          "temperatureDescription": "Более высокие значения дают более случайные результаты (0-1). Поддерживается только whisper-1.",
+          "languageHints": "Языковые подсказки",
+          "languageHintsStrict": "Строгие языковые подсказки",
+          "languageHintsStrictDescription": "Транскрибировать только на указанных языках",
+          "contextTerms": "Контекстные термины",
+          "contextTermsDescription": "Термины через запятую для повышения точности распознавания",
+          "contextDescription": "Описание контекста",
+          "contextDescriptionDescription": "Произвольный текст с общим контекстом об аудиоконтенте",
+          "enableSpeakerDiarization": "Диаризация спикеров",
+          "enableSpeakerDiarizationDescription": "Определять и разделять разных говорящих",
+          "enableLanguageIdentification": "Определение языка",
+          "enableLanguageIdentificationDescription": "Определять язык для каждого сегмента"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Локальные модели"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Модели не настроены. Перейдите в Библиотеку, чтобы загрузить модели или настроить облачных провайдеров."
       }
     },
     "general": {
@@ -266,11 +266,11 @@
         "description": "Удерживайте, чтобы записать, отпустите, чтобы остановить"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Горячие клавиши",
+        "strategyNone": "Нет",
+        "addNew": "Добавить горячую клавишу",
+        "remove": "Удалить горячую клавишу",
+        "postProcessNotReady": "Сначала настройте провайдера постобработки"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Вывод",
         "transcription": "Транскрипция",
         "history": "История",
-        "data": "Data",
+        "data": "Данные",
         "configuration": "Конфигурация"
       },
       "startHidden": {
@@ -334,7 +334,7 @@
           "none": "Нет",
           "externalScript": "Внешний скрипт"
         },
-        "externalScriptPlaceholder": "/path/to/your/script.sh"
+        "externalScriptPlaceholder": "/путь/к/вашему/скрипту.sh"
       },
       "typingTool": {
         "title": "Инструмент ввода",
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" уже существует"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Экспорт данных",
+        "description": "Экспортировать настройки, историю и записи в файл",
+        "button": "Экспорт...",
+        "includeSettings": "Настройки",
+        "includeHistory": "История транскрипций",
+        "includeRecordings": "Аудиозаписи",
+        "success": "Данные успешно экспортированы",
+        "error": "Не удалось экспортировать данные"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Импорт данных",
+        "description": "Импортировать настройки и данные из ранее экспортированного файла",
+        "button": "Импорт...",
+        "previewTitle": "Предварительный просмотр импорта",
+        "exportDate": "Экспортировано {{date}}",
+        "appVersion": "Версия приложения: {{version}}",
+        "historyCount": "{{count}} записей истории",
+        "recordingsCount": "{{count}} записей",
+        "statsCount": "{{count}} записей статистики речи",
+        "importSettings": "Настройки",
+        "importRecordings": "Записи",
+        "warning": "Импорт настроек перезапишет текущую конфигурацию. Файл экспорта может содержать API-ключи.",
+        "success": "Данные успешно импортированы",
+        "error": "Не удалось импортировать данные",
+        "invalidFile": "Выбранный файл не является корректным экспортом Handless"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Тема",
+        "description": "Выберите цветовую тему приложения",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Тёмная",
+          "light": "Светлая",
+          "system": "Системная"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "Удалить из сохраненных",
       "delete": "Удалить запись",
       "deleteError": "Не удалось удалить запись. Пожалуйста, попробуйте еще раз.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Скрыть оригинал",
+      "showOriginal": "Показать оригинал"
     },
     "debug": {
       "title": "Отлаживать",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Звуковая тема",
         "description": "Выберите звуковую тему для начала и остановки записи обратной связи.",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Прослушать звуковую тему (воспроизведёт старт и стоп)"
       },
       "wordCorrectionThreshold": {
         "title": "Порог исправления слов",
@@ -659,8 +659,8 @@
     "yes": "Да",
     "no": "Нет",
     "noOptionsFound": "Вариантов не найдено",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Скопировать в буфер обмена",
+    "search": "Поиск..."
   },
   "accessibility": {
     "permissionsRequired": "Требуются разрешения на доступ",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Hızlı ve doğru."
+        "description": "Hızlı ve doğru. 25 Avrupa dilini destekler."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "OpenAI'nin bulut konuşmadan metne API'si. 57'den fazla dil desteğiyle hızlı ve doğru."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Soniox bulut konuşmadan metne. Gerçek zamanlı transkripsiyon ile yüksek doğruluk."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "İptal",
     "cancelDownload": "İndirmeyi iptal et",
-    "notAvailable": "Not Available"
+    "notAvailable": "Kullanılamıyor"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "İndirilen modeller",
       "availableModels": "İndirilebilir",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Modellerim",
+        "library": "Kütüphane"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "Bulut Sağlayıcıları",
+        "badge": "Bulut",
+        "notConfigured": "Yapılandırılmadı",
+        "verify": "Doğrula",
+        "verifying": "Doğrulanıyor...",
+        "verified": "Doğrulandı",
+        "verifyFailed": "Doğrulama başarısız",
+        "verifyFirst": "Önce API Key doğrulayın",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
           "title": "Model",
-          "placeholder": "Enter model name"
+          "placeholder": "Model adı girin"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "API Key al",
+        "realtimeTranscription": "Gerçek zamanlı transkripsiyon",
+        "realtimeDescription": "Daha düşük gecikme için dosya yüklemesi yerine WebSocket bağlantısı kullanır",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Dil",
+          "selectLanguage": "Otomatik algıla",
+          "selectLanguageHint": "Otomatik algılama için boş bırakın",
+          "selectLanguages": "Dil seçin...",
+          "selectTranslate": "Dil seçin...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Modelin stilini yönlendirmek veya önceki bir bölümü devam ettirmek için isteğe bağlı metin. gpt-4o-transcribe-diarize tarafından desteklenmez.",
+          "temperature": "Sıcaklık",
+          "temperatureDescription": "Daha yüksek değerler daha rastgele sonuçlar üretir (0-1). Yalnızca whisper-1 tarafından desteklenir.",
+          "languageHints": "Dil İpuçları",
+          "languageHintsStrict": "Katı Dil İpuçları",
+          "languageHintsStrictDescription": "Yalnızca belirtilen dillerde transkribe et",
+          "contextTerms": "Bağlam Terimleri",
+          "contextTermsDescription": "Tanıma doğruluğunu artırmak için virgülle ayrılmış terimler",
+          "contextDescription": "Bağlam Açıklaması",
+          "contextDescriptionDescription": "Ses içeriği hakkında genel bağlam sağlayan serbest metin",
+          "enableSpeakerDiarization": "Konuşmacı Ayrımı",
+          "enableSpeakerDiarizationDescription": "Farklı konuşmacıları tanımlayıp ayırır",
+          "enableLanguageIdentification": "Dil Tanımlama",
+          "enableLanguageIdentificationDescription": "Her segment için dili algıla"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Yerel Modeller"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Yapılandırılmış model yok. Modelleri indirmek veya bulut sağlayıcıları ayarlamak için Kütüphane'yi ziyaret edin."
       }
     },
     "general": {
@@ -266,11 +266,11 @@
         "description": "Kaydetmek için basılı tutun, durdurmak için bırakın"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Kısayollar",
+        "strategyNone": "Yok",
+        "addNew": "Kısayol Ekle",
+        "remove": "Kısayolu kaldır",
+        "postProcessNotReady": "Önce bir son işlem sağlayıcısı yapılandırın"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Çıktı",
         "transcription": "Transkripsiyon",
         "history": "Geçmiş",
-        "data": "Data",
+        "data": "Veri",
         "configuration": "Yapılandırma"
       },
       "startHidden": {
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" zaten mevcut"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Veriyi Dışa Aktar",
+        "description": "Ayarlarınızı, geçmişinizi ve kayıtlarınızı bir dosyaya aktarın",
+        "button": "Dışa Aktar...",
+        "includeSettings": "Ayarlar",
+        "includeHistory": "Transkripsiyon Geçmişi",
+        "includeRecordings": "Ses Kayıtları",
+        "success": "Veriler başarıyla dışa aktarıldı",
+        "error": "Veriler dışa aktarılamadı"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Veriyi İçe Aktar",
+        "description": "Daha önce dışa aktarılmış bir dosyadan ayarları ve verileri içe aktarın",
+        "button": "İçe Aktar...",
+        "previewTitle": "İçe Aktarma Önizlemesi",
+        "exportDate": "{{date}} tarihinde dışa aktarıldı",
+        "appVersion": "Uygulama sürümü: {{version}}",
+        "historyCount": "{{count}} geçmiş kaydı",
+        "recordingsCount": "{{count}} kayıt",
+        "statsCount": "{{count}} konuşma istatistiği",
+        "importSettings": "Ayarlar",
+        "importRecordings": "Kayıtlar",
+        "warning": "Ayarları içe aktarmak mevcut yapılandırmanızın üzerine yazacaktır. Dışa aktarma dosyası API Key içerebilir.",
+        "success": "Veriler başarıyla içe aktarıldı",
+        "error": "Veriler içe aktarılamadı",
+        "invalidFile": "Seçilen dosya geçerli bir Handless dışa aktarması değil"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Tema",
+        "description": "Uygulama renk temasını seçin",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Koyu",
+          "light": "Açık",
+          "system": "Sistem"
         }
       },
       "configFile": {
@@ -473,7 +473,7 @@
         "verified": "Doğrulandı"
       },
       "prompts": {
-        "title": "Prompt",
+        "title": "İstem",
         "selectedPrompt": {
           "title": "Seçili Prompt",
           "description": "Transkripsiyonları iyileştirmek için bir şablon seçin veya yeni bir tane oluşturun. Yakalanan transkript otomatik olarak prompt'a sağlanır."
@@ -526,8 +526,8 @@
       "unsave": "Kaydedilenlerden kaldır",
       "delete": "Kaydı sil",
       "deleteError": "Kayıt silinemedi. Lütfen tekrar deneyin.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Orijinali gizle",
+      "showOriginal": "Orijinali göster"
     },
     "debug": {
       "title": "Hata Ayıklama",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Ses Teması",
         "description": "Kayıt başlangıç ve bitişi için sesli geri bildirim temasını seçin",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Ses temasını önizle (başlatma ve durdurma seslerini çalar)"
       },
       "wordCorrectionThreshold": {
         "title": "Kelime Düzeltme Eşiği",
@@ -659,8 +659,8 @@
     "yes": "Evet",
     "no": "Hayır",
     "noOptionsFound": "Seçenek bulunamadı",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Panoya kopyala",
+    "search": "Ara..."
   },
   "accessibility": {
     "permissionsRequired": "Erişilebilirlik İzinleri Gerekli",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Швидка та точна"
+        "description": "Швидка та точна. Підтримує 25 європейських мов."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "Хмарний API розпізнавання мовлення OpenAI. Швидкий і точний з підтримкою 57+ мов."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Хмарне розпізнавання мовлення Soniox. Висока точність з транскрипцією в реальному часі."
       }
     }
   },
@@ -132,7 +132,7 @@
     "noModelDownloadRequired": "Немає моделі - потрібно завантажити",
     "deleteModel": "Видалити {{modelName}}",
     "switching": "Перемикання...",
-    "downloadSpeed": "{{speed}} MB/s",
+    "downloadSpeed": "{{speed}} МБ/с",
     "capabilities": {
       "languageSelection": "Підтримує кілька мов введення",
       "multiLanguage": "Багатомовна",
@@ -143,7 +143,7 @@
     },
     "cancel": "Скасувати",
     "cancelDownload": "Скасувати завантаження",
-    "notAvailable": "Not Available"
+    "notAvailable": "Недоступно"
   },
   "settings": {
     "modelSettings": {
@@ -192,11 +192,11 @@
         "description": "Утримуйте для запису, відпустіть для зупинки"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Гарячі клавіші",
+        "strategyNone": "Немає",
+        "addNew": "Додати гарячу клавішу",
+        "remove": "Видалити гарячу клавішу",
+        "postProcessNotReady": "Спочатку налаштуйте провайдера постобробки"
       }
     },
     "models": {
@@ -217,60 +217,60 @@
       "yourModels": "Завантажені моделі",
       "availableModels": "Доступні для завантаження",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Мої моделі",
+        "library": "Бібліотека"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "Хмарні провайдери",
+        "badge": "Хмара",
+        "notConfigured": "Не налаштовано",
+        "verify": "Перевірити",
+        "verifying": "Перевірка...",
+        "verified": "Перевірено",
+        "verifyFailed": "Перевірка не вдалася",
+        "verifyFirst": "Спочатку перевірте ваш API Key",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Модель",
+          "placeholder": "Введіть назву моделі"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Отримати API Key",
+        "realtimeTranscription": "Транскрипція в реальному часі",
+        "realtimeDescription": "Використовує WebSocket-з'єднання замість завантаження файлу для зменшення затримки",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
-          "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "language": "Мова",
+          "selectLanguage": "Автовизначення",
+          "selectLanguageHint": "Залиште порожнім для автовизначення",
+          "selectLanguages": "Оберіть мови...",
+          "selectTranslate": "Оберіть мови...",
+          "prompt": "Промпт",
+          "promptDescription": "Необов'язковий текст для керування стилем моделі або продовження попереднього сегмента. Не підтримується gpt-4o-transcribe-diarize.",
+          "temperature": "Температура",
+          "temperatureDescription": "Вищі значення дають більш випадкові результати (0-1). Підтримується лише whisper-1.",
+          "languageHints": "Мовні підказки",
+          "languageHintsStrict": "Суворі мовні підказки",
+          "languageHintsStrictDescription": "Транскрибувати лише вказаними мовами",
+          "contextTerms": "Контекстні терміни",
+          "contextTermsDescription": "Терміни через кому для покращення точності розпізнавання",
+          "contextDescription": "Опис контексту",
+          "contextDescriptionDescription": "Довільний текст із загальним контекстом про аудіовміст",
+          "enableSpeakerDiarization": "Діаризація спікерів",
+          "enableSpeakerDiarizationDescription": "Визначати та розділяти різних мовців",
+          "enableLanguageIdentification": "Визначення мови",
+          "enableLanguageIdentificationDescription": "Визначати мову для кожного сегмента"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Локальні моделі"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Моделі не налаштовані. Перейдіть до Бібліотеки, щоб завантажити моделі або налаштувати хмарних провайдерів."
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Вивід",
         "transcription": "Транскрипція",
         "history": "Історія",
-        "data": "Data",
+        "data": "Дані",
         "configuration": "Конфігурація"
       },
       "startHidden": {
@@ -334,7 +334,7 @@
           "none": "Немає",
           "externalScript": "Зовнішній скрипт"
         },
-        "externalScriptPlaceholder": "/path/to/your/script.sh"
+        "externalScriptPlaceholder": "/шлях/до/вашого/скрипту.sh"
       },
       "typingTool": {
         "title": "Інструмент введення",
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" вже існує"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Експорт даних",
+        "description": "Експортувати налаштування, історію та записи у файл",
+        "button": "Експорт...",
+        "includeSettings": "Налаштування",
+        "includeHistory": "Історія транскрипцій",
+        "includeRecordings": "Аудіозаписи",
+        "success": "Дані успішно експортовано",
+        "error": "Не вдалося експортувати дані"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Імпорт даних",
+        "description": "Імпортувати налаштування та дані з раніше експортованого файлу",
+        "button": "Імпорт...",
+        "previewTitle": "Попередній перегляд імпорту",
+        "exportDate": "Експортовано {{date}}",
+        "appVersion": "Версія додатку: {{version}}",
+        "historyCount": "{{count}} записів історії",
+        "recordingsCount": "{{count}} записів",
+        "statsCount": "{{count}} записів статистики мовлення",
+        "importSettings": "Налаштування",
+        "importRecordings": "Записи",
+        "warning": "Імпорт налаштувань перезапише поточну конфігурацію. Файл експорту може містити API-ключі.",
+        "success": "Дані успішно імпортовано",
+        "error": "Не вдалося імпортувати дані",
+        "invalidFile": "Обраний файл не є коректним експортом Handless"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Тема",
+        "description": "Оберіть кольорову тему додатку",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Темна",
+          "light": "Світла",
+          "system": "Системна"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "Видалити зі збережених",
       "delete": "Видалити запис",
       "deleteError": "Не вдалося видалити запис. Спробуйте ще раз.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Сховати оригінал",
+      "showOriginal": "Показати оригінал"
     },
     "debug": {
       "title": "Дебаг",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Звукова тема",
         "description": "Оберіть звукову тему для сповіщень про початок і зупинку запису",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Прослухати звукову тему (відтворить старт і стоп)"
       },
       "wordCorrectionThreshold": {
         "title": "Поріг корекції слів",
@@ -659,8 +659,8 @@
     "yes": "Так",
     "no": "Ні",
     "noOptionsFound": "Опцій не знайдено",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Скопіювати в буфер обміну",
+    "search": "Пошук..."
   },
   "accessibility": {
     "permissionsRequired": "Потрібні права доступу",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "Nhanh và chính xác"
+        "description": "Nhanh và chính xác. Hỗ trợ 25 ngôn ngữ châu Âu."
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "API chuyển đổi giọng nói thành văn bản đám mây của OpenAI. Nhanh và chính xác, hỗ trợ hơn 57 ngôn ngữ."
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Chuyển đổi giọng nói thành văn bản đám mây Soniox. Độ chính xác cao với chuyển đổi thời gian thực."
       }
     }
   },
@@ -143,7 +143,7 @@
     },
     "cancel": "Hủy",
     "cancelDownload": "Hủy tải xuống",
-    "notAvailable": "Not Available"
+    "notAvailable": "Không khả dụng"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "Mô hình đã tải",
       "availableModels": "Có sẵn để tải xuống",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "Mô hình của tôi",
+        "library": "Thư viện"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "Nhà cung cấp đám mây",
+        "badge": "Đám mây",
+        "notConfigured": "Chưa cấu hình",
+        "verify": "Xác minh",
+        "verifying": "Đang xác minh...",
+        "verified": "Đã xác minh",
+        "verifyFailed": "Xác minh thất bại",
+        "verifyFirst": "Vui lòng xác minh API Key trước",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "Mô hình",
+          "placeholder": "Nhập tên mô hình"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "Lấy API Key",
+        "realtimeTranscription": "Chuyển đổi thời gian thực",
+        "realtimeDescription": "Sử dụng kết nối WebSocket thay vì tải tệp lên để giảm độ trễ",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
+          "language": "Ngôn ngữ",
+          "selectLanguage": "Tự động phát hiện",
+          "selectLanguageHint": "Để trống để tự động phát hiện",
+          "selectLanguages": "Chọn ngôn ngữ...",
+          "selectTranslate": "Chọn ngôn ngữ...",
           "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "promptDescription": "Văn bản tùy chọn để hướng dẫn phong cách của mô hình hoặc tiếp tục đoạn trước. Không được hỗ trợ bởi gpt-4o-transcribe-diarize.",
+          "temperature": "Nhiệt độ",
+          "temperatureDescription": "Giá trị cao hơn tạo kết quả ngẫu nhiên hơn (0-1). Chỉ được hỗ trợ bởi whisper-1.",
+          "languageHints": "Gợi ý ngôn ngữ",
+          "languageHintsStrict": "Gợi ý ngôn ngữ nghiêm ngặt",
+          "languageHintsStrictDescription": "Chỉ chuyển đổi bằng các ngôn ngữ đã chỉ định",
+          "contextTerms": "Thuật ngữ ngữ cảnh",
+          "contextTermsDescription": "Các thuật ngữ phân cách bằng dấu phẩy để cải thiện độ chính xác nhận dạng",
+          "contextDescription": "Mô tả ngữ cảnh",
+          "contextDescriptionDescription": "Văn bản tự do cung cấp ngữ cảnh chung về nội dung âm thanh",
+          "enableSpeakerDiarization": "Phân biệt người nói",
+          "enableSpeakerDiarizationDescription": "Nhận diện và tách biệt các người nói khác nhau",
+          "enableLanguageIdentification": "Nhận diện ngôn ngữ",
+          "enableLanguageIdentificationDescription": "Phát hiện ngôn ngữ cho từng đoạn"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "Mô hình cục bộ"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "Chưa cấu hình mô hình nào. Truy cập Thư viện để tải mô hình hoặc thiết lập nhà cung cấp đám mây."
       }
     },
     "general": {
@@ -266,11 +266,11 @@
         "description": "Giữ để ghi âm, thả để dừng"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "Phím tắt",
+        "strategyNone": "Không có",
+        "addNew": "Thêm phím tắt",
+        "remove": "Xóa phím tắt",
+        "postProcessNotReady": "Vui lòng cấu hình nhà cung cấp xử lý sau trước"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "Đầu ra",
         "transcription": "Chuyển đổi",
         "history": "Lịch sử",
-        "data": "Data",
+        "data": "Dữ liệu",
         "configuration": "Cấu hình"
       },
       "startHidden": {
@@ -327,9 +327,9 @@
         "title": "Phương thức dán",
         "description": "Chọn cách chèn văn bản. Trực tiếp: mô phỏng gõ phím qua đầu vào hệ thống. Không có: bỏ qua dán, chỉ cập nhật lịch sử/clipboard.",
         "options": {
-          "clipboard": "Clipboard ({{modifier}}+V)",
-          "clipboardCtrlShiftV": "Clipboard (Ctrl+Shift+V)",
-          "clipboardShiftInsert": "Clipboard (Shift+Insert)",
+          "clipboard": "Bảng nhớ tạm ({{modifier}}+V)",
+          "clipboardCtrlShiftV": "Bảng nhớ tạm (Ctrl+Shift+V)",
+          "clipboardShiftInsert": "Bảng nhớ tạm (Shift+Insert)",
           "direct": "Trực tiếp",
           "none": "Không có",
           "externalScript": "Script bên ngoài"
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" đã tồn tại"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "Xuất dữ liệu",
+        "description": "Xuất cài đặt, lịch sử và bản ghi âm của bạn ra tệp",
+        "button": "Xuất...",
+        "includeSettings": "Cài đặt",
+        "includeHistory": "Lịch sử chuyển đổi",
+        "includeRecordings": "Bản ghi âm",
+        "success": "Xuất dữ liệu thành công",
+        "error": "Không thể xuất dữ liệu"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "Nhập dữ liệu",
+        "description": "Nhập cài đặt và dữ liệu từ tệp đã xuất trước đó",
+        "button": "Nhập...",
+        "previewTitle": "Xem trước nhập",
+        "exportDate": "Đã xuất vào {{date}}",
+        "appVersion": "Phiên bản ứng dụng: {{version}}",
+        "historyCount": "{{count}} mục lịch sử",
+        "recordingsCount": "{{count}} bản ghi âm",
+        "statsCount": "{{count}} thống kê nói",
+        "importSettings": "Cài đặt",
+        "importRecordings": "Bản ghi âm",
+        "warning": "Nhập cài đặt sẽ ghi đè cấu hình hiện tại của bạn. Tệp xuất có thể chứa API Key.",
+        "success": "Nhập dữ liệu thành công",
+        "error": "Không thể nhập dữ liệu",
+        "invalidFile": "Tệp đã chọn không phải là tệp xuất Handless hợp lệ"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "Giao diện",
+        "description": "Chọn giao diện màu sắc cho ứng dụng",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "Tối",
+          "light": "Sáng",
+          "system": "Hệ thống"
         }
       },
       "configFile": {
@@ -473,9 +473,9 @@
         "verified": "Đã xác minh"
       },
       "prompts": {
-        "title": "Prompt",
+        "title": "Chỉ thị",
         "selectedPrompt": {
-          "title": "Prompt đã chọn",
+          "title": "Chỉ thị đã chọn",
           "description": "Chọn một mẫu để tinh chỉnh bản ghi hoặc tạo mới. Bản ghi đã chụp được tự động cung cấp cho prompt."
         },
         "noPrompts": "Không có prompt nào",
@@ -526,8 +526,8 @@
       "unsave": "Xóa khỏi đã lưu",
       "delete": "Xóa mục",
       "deleteError": "Không thể xóa mục. Vui lòng thử lại.",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "Ẩn bản gốc",
+      "showOriginal": "Hiện bản gốc"
     },
     "debug": {
       "title": "Gỡ lỗi",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "Chủ đề âm thanh",
         "description": "Chọn chủ đề âm thanh cho phản hồi bắt đầu và kết thúc ghi âm",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "Xem trước chủ đề âm thanh (phát bắt đầu rồi dừng)"
       },
       "wordCorrectionThreshold": {
         "title": "Ngưỡng sửa từ",
@@ -659,8 +659,8 @@
     "yes": "Có",
     "no": "Không",
     "noOptionsFound": "Không tìm thấy tùy chọn",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "Sao chép vào clipboard",
+    "search": "Tìm kiếm..."
   },
   "accessibility": {
     "permissionsRequired": "Cần quyền truy cập",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "快速且準確"
+        "description": "快速且準確。支援25種歐洲語言。"
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "OpenAI 雲端語音轉文字 API。快速準確，支援 57 種以上語言。"
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Soniox 雲端語音轉文字。高準確度，支援即時轉錄。"
       }
     }
   },
@@ -132,7 +132,7 @@
     "modelUnloaded": "模型已卸載",
     "noModelDownloadRequired": "無模型 - 需要下載",
     "deleteModel": "刪除 {{modelName}}",
-    "downloadSpeed": "{{speed}} MB/s",
+    "downloadSpeed": "{{speed}} MB/秒",
     "cancel": "取消",
     "cancelDownload": "取消下載",
     "capabilities": {
@@ -143,7 +143,7 @@
       "translation": "可翻譯為英語",
       "translate": "翻譯為英語"
     },
-    "notAvailable": "Not Available"
+    "notAvailable": "不可用"
   },
   "settings": {
     "modelSettings": {
@@ -192,11 +192,11 @@
         "description": "按住錄製，放開停止"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "快捷鍵",
+        "strategyNone": "無",
+        "addNew": "新增快捷鍵",
+        "remove": "移除快捷鍵",
+        "postProcessNotReady": "請先設定後處理供應商"
       }
     },
     "models": {
@@ -217,60 +217,60 @@
       },
       "noModelsMatch": "沒有符合此篩選條件的模型",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "我的模型",
+        "library": "模型庫"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "雲端供應商",
+        "badge": "雲端",
+        "notConfigured": "未設定",
+        "verify": "驗證",
+        "verifying": "驗證中...",
+        "verified": "已驗證",
+        "verifyFailed": "驗證失敗",
+        "verifyFirst": "請先驗證您的 API Key",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "模型",
+          "placeholder": "輸入模型名稱"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "取得 API Key",
+        "realtimeTranscription": "即時轉錄",
+        "realtimeDescription": "使用 WebSocket 連線取代檔案上傳，以降低延遲",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
-          "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "language": "語言",
+          "selectLanguage": "自動偵測",
+          "selectLanguageHint": "留空以自動偵測",
+          "selectLanguages": "選擇語言...",
+          "selectTranslate": "選擇語言...",
+          "prompt": "提示詞",
+          "promptDescription": "可選文字，用於引導模型風格或接續上一段內容。gpt-4o-transcribe-diarize 不支援此功能。",
+          "temperature": "溫度",
+          "temperatureDescription": "值越高結果越隨機（0-1）。僅 whisper-1 支援。",
+          "languageHints": "語言提示",
+          "languageHintsStrict": "嚴格語言提示",
+          "languageHintsStrictDescription": "僅轉錄指定的語言",
+          "contextTerms": "上下文術語",
+          "contextTermsDescription": "以逗號分隔的術語，用於提高辨識準確度",
+          "contextDescription": "上下文描述",
+          "contextDescriptionDescription": "自由文字，提供有關音訊內容的一般上下文",
+          "enableSpeakerDiarization": "說話者分離",
+          "enableSpeakerDiarizationDescription": "辨識並區分不同的說話者",
+          "enableLanguageIdentification": "語言辨識",
+          "enableLanguageIdentificationDescription": "偵測每個片段的語言"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "本機模型"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "尚未設定模型。前往模型庫下載模型或設定雲端供應商。"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "輸出",
         "transcription": "轉錄",
         "history": "歷史",
-        "data": "Data",
+        "data": "資料",
         "configuration": "設定"
       },
       "startHidden": {
@@ -334,7 +334,7 @@
           "none": "無",
           "externalScript": "外部腳本"
         },
-        "externalScriptPlaceholder": "/path/to/your/script.sh"
+        "externalScriptPlaceholder": "/您的/腳本/路徑.sh"
       },
       "typingTool": {
         "title": "輸入工具",
@@ -390,39 +390,39 @@
         "duplicate": "「{{word}}」已存在"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "匯出資料",
+        "description": "將設定、歷史紀錄和錄音匯出到檔案",
+        "button": "匯出...",
+        "includeSettings": "設定",
+        "includeHistory": "轉錄歷史",
+        "includeRecordings": "音訊錄音",
+        "success": "資料匯出成功",
+        "error": "資料匯出失敗"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "匯入資料",
+        "description": "從先前匯出的檔案中匯入設定和資料",
+        "button": "匯入...",
+        "previewTitle": "匯入預覽",
+        "exportDate": "匯出於 {{date}}",
+        "appVersion": "應用程式版本: {{version}}",
+        "historyCount": "{{count}} 筆歷史紀錄",
+        "recordingsCount": "{{count}} 筆錄音",
+        "statsCount": "{{count}} 筆語音統計",
+        "importSettings": "設定",
+        "importRecordings": "錄音",
+        "warning": "匯入設定將覆寫您目前的設定。匯出檔案可能包含 API Key。",
+        "success": "資料匯入成功",
+        "error": "資料匯入失敗",
+        "invalidFile": "所選檔案不是有效的 Handless 匯出檔案"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "主題",
+        "description": "選擇應用程式色彩主題",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "深色",
+          "light": "淺色",
+          "system": "跟隨系統"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "從已儲存中移除",
       "delete": "刪除條目",
       "deleteError": "刪除條目失敗，請重試",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "隱藏原文",
+      "showOriginal": "顯示原文"
     },
     "debug": {
       "title": "偵錯",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "聲音主題",
         "description": "選擇錄製開始和停止回饋的聲音主題",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "預覽聲音主題（播放開始和停止聲音）"
       },
       "wordCorrectionThreshold": {
         "title": "詞彙修正閾值",
@@ -659,8 +659,8 @@
     "yes": "是",
     "no": "否",
     "noOptionsFound": "未找到選項",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "複製到剪貼簿",
+    "search": "搜尋..."
   },
   "accessibility": {
     "permissionsRequired": "需要輔助使用權限",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -53,7 +53,7 @@
       },
       "parakeet-tdt-0.6b-v3": {
         "name": "Parakeet V3",
-        "description": "快速且准确"
+        "description": "快速且准确。支持25种欧洲语言。"
       },
       "moonshine-base": {
         "name": "Moonshine Base",
@@ -107,11 +107,11 @@
     "cloud": {
       "openai_stt": {
         "name": "OpenAI",
-        "description": "OpenAI's cloud speech-to-text API. Fast and accurate with support for 57+ languages."
+        "description": "OpenAI 云端语音转文字 API。快速准确，支持 57 种以上语言。"
       },
       "soniox": {
         "name": "Soniox",
-        "description": "Soniox cloud speech-to-text. High accuracy with async transcription."
+        "description": "Soniox 云端语音转文字。高准确度，支持实时转录。"
       }
     }
   },
@@ -132,7 +132,7 @@
     "modelUnloaded": "模型已卸载",
     "noModelDownloadRequired": "无模型 - 需要下载",
     "deleteModel": "删除 {{modelName}}",
-    "downloadSpeed": "{{speed}} MB/s",
+    "downloadSpeed": "{{speed}} MB/秒",
     "capabilities": {
       "languageSelection": "支持多种输入语言",
       "multiLanguage": "多语言",
@@ -143,7 +143,7 @@
     },
     "cancel": "取消",
     "cancelDownload": "取消下载",
-    "notAvailable": "Not Available"
+    "notAvailable": "不可用"
   },
   "settings": {
     "modelSettings": {
@@ -168,60 +168,60 @@
       "yourModels": "已下载的模型",
       "availableModels": "可供下载",
       "tabs": {
-        "myModels": "My Models",
-        "library": "Library"
+        "myModels": "我的模型",
+        "library": "模型库"
       },
       "cloudProviders": {
-        "title": "Cloud Providers",
-        "badge": "Cloud",
-        "notConfigured": "Not configured",
-        "verify": "Verify",
-        "verifying": "Verifying...",
-        "verified": "Verified",
-        "verifyFailed": "Verification failed",
-        "verifyFirst": "Verify your API key first",
+        "title": "云端提供商",
+        "badge": "云端",
+        "notConfigured": "未配置",
+        "verify": "验证",
+        "verifying": "验证中...",
+        "verified": "已验证",
+        "verifyFailed": "验证失败",
+        "verifyFirst": "请先验证您的 API Key",
         "apiKey": {
           "title": "API Key",
           "placeholder": "sk-..."
         },
         "model": {
-          "title": "Model",
-          "placeholder": "Enter model name"
+          "title": "模型",
+          "placeholder": "输入模型名称"
         },
         "baseUrl": {
           "title": "Base URL"
         },
-        "getApiKey": "Get API key",
-        "realtimeTranscription": "Real-time transcription",
-        "realtimeDescription": "Uses a WebSocket connection instead of file upload for lower latency",
+        "getApiKey": "获取 API Key",
+        "realtimeTranscription": "实时转录",
+        "realtimeDescription": "使用 WebSocket 连接替代文件上传，以降低延迟",
         "options": {
-          "language": "Language",
-          "selectLanguage": "Auto detect",
-          "selectLanguageHint": "Leave empty to auto detect",
-          "selectLanguages": "Select languages...",
-          "selectTranslate": "Select languages...",
-          "prompt": "Prompt",
-          "promptDescription": "Optional text to guide the model's style or continue a previous segment. Not supported by gpt-4o-transcribe-diarize.",
-          "temperature": "Temperature",
-          "temperatureDescription": "Higher values produce more random results (0-1). Only supported by whisper-1.",
-          "languageHints": "Language Hints",
-          "languageHintsStrict": "Strict Language Hints",
-          "languageHintsStrictDescription": "Only transcribe in the specified languages",
-          "contextTerms": "Context Terms",
-          "contextTermsDescription": "Comma-separated terms to improve recognition accuracy",
-          "contextDescription": "Context Description",
-          "contextDescriptionDescription": "Freeform text providing general context about the audio content",
-          "enableSpeakerDiarization": "Speaker Diarization",
-          "enableSpeakerDiarizationDescription": "Identify and separate different speakers",
-          "enableLanguageIdentification": "Language Identification",
-          "enableLanguageIdentificationDescription": "Detect language for each segment"
+          "language": "语言",
+          "selectLanguage": "自动检测",
+          "selectLanguageHint": "留空以自动检测",
+          "selectLanguages": "选择语言...",
+          "selectTranslate": "选择语言...",
+          "prompt": "提示词",
+          "promptDescription": "可选文本，用于引导模型风格或续接上一段内容。gpt-4o-transcribe-diarize 不支持此功能。",
+          "temperature": "温度",
+          "temperatureDescription": "值越高结果越随机（0-1）。仅 whisper-1 支持。",
+          "languageHints": "语言提示",
+          "languageHintsStrict": "严格语言提示",
+          "languageHintsStrictDescription": "仅转录指定的语言",
+          "contextTerms": "上下文术语",
+          "contextTermsDescription": "以逗号分隔的术语，用于提高识别准确度",
+          "contextDescription": "上下文描述",
+          "contextDescriptionDescription": "自由文本，提供有关音频内容的一般上下文",
+          "enableSpeakerDiarization": "说话人分离",
+          "enableSpeakerDiarizationDescription": "识别并区分不同的说话人",
+          "enableLanguageIdentification": "语言识别",
+          "enableLanguageIdentificationDescription": "检测每个片段的语言"
         }
       },
       "localModels": {
-        "title": "Local Models"
+        "title": "本地模型"
       },
       "myModels": {
-        "noModelsConfigured": "No models configured. Visit the Library to download models or set up cloud providers."
+        "noModelsConfigured": "尚未配置模型。前往模型库下载模型或设置云端提供商。"
       }
     },
     "general": {
@@ -266,11 +266,11 @@
         "description": "按住录制，松开停止"
       },
       "shortcuts": {
-        "title": "Shortcuts",
-        "strategyNone": "None",
-        "addNew": "Add Shortcut",
-        "remove": "Remove shortcut",
-        "postProcessNotReady": "Configure a post-processing provider first"
+        "title": "快捷键",
+        "strategyNone": "无",
+        "addNew": "添加快捷键",
+        "remove": "移除快捷键",
+        "postProcessNotReady": "请先配置后处理提供商"
       }
     },
     "sound": {
@@ -299,7 +299,7 @@
         "output": "输出",
         "transcription": "转录",
         "history": "历史",
-        "data": "Data",
+        "data": "数据",
         "configuration": "配置"
       },
       "startHidden": {
@@ -334,7 +334,7 @@
           "none": "无",
           "externalScript": "外部脚本"
         },
-        "externalScriptPlaceholder": "/path/to/your/script.sh"
+        "externalScriptPlaceholder": "/你的/脚本/路径.sh"
       },
       "typingTool": {
         "title": "输入工具",
@@ -390,39 +390,39 @@
         "duplicate": "\"{{word}}\" 已存在"
       },
       "exportData": {
-        "title": "Export Data",
-        "description": "Export your settings, history, and recordings to a file",
-        "button": "Export...",
-        "includeSettings": "Settings",
-        "includeHistory": "Transcription History",
-        "includeRecordings": "Audio Recordings",
-        "success": "Data exported successfully",
-        "error": "Failed to export data"
+        "title": "导出数据",
+        "description": "将设置、历史记录和录音导出到文件",
+        "button": "导出...",
+        "includeSettings": "设置",
+        "includeHistory": "转录历史",
+        "includeRecordings": "音频录音",
+        "success": "数据导出成功",
+        "error": "数据导出失败"
       },
       "importData": {
-        "title": "Import Data",
-        "description": "Import settings and data from a previously exported file",
-        "button": "Import...",
-        "previewTitle": "Import Preview",
-        "exportDate": "Exported on {{date}}",
-        "appVersion": "App version: {{version}}",
-        "historyCount": "{{count}} history entries",
-        "recordingsCount": "{{count}} recordings",
-        "statsCount": "{{count}} speaking stats",
-        "importSettings": "Settings",
-        "importRecordings": "Recordings",
-        "warning": "Importing settings will overwrite your current configuration. The export file may contain API keys.",
-        "success": "Data imported successfully",
-        "error": "Failed to import data",
-        "invalidFile": "The selected file is not a valid Handless export"
+        "title": "导入数据",
+        "description": "从之前导出的文件中导入设置和数据",
+        "button": "导入...",
+        "previewTitle": "导入预览",
+        "exportDate": "导出于 {{date}}",
+        "appVersion": "应用版本: {{version}}",
+        "historyCount": "{{count}} 条历史记录",
+        "recordingsCount": "{{count}} 条录音",
+        "statsCount": "{{count}} 条语音统计",
+        "importSettings": "设置",
+        "importRecordings": "录音",
+        "warning": "导入设置将覆盖您当前的配置。导出文件可能包含 API Key。",
+        "success": "数据导入成功",
+        "error": "数据导入失败",
+        "invalidFile": "所选文件不是有效的 Handless 导出文件"
       },
       "theme": {
-        "title": "Theme",
-        "description": "Choose the app color theme",
+        "title": "主题",
+        "description": "选择应用颜色主题",
         "options": {
-          "dark": "Dark",
-          "light": "Light",
-          "system": "System"
+          "dark": "深色",
+          "light": "浅色",
+          "system": "跟随系统"
         }
       },
       "configFile": {
@@ -526,8 +526,8 @@
       "unsave": "从已保存中移除",
       "delete": "删除条目",
       "deleteError": "删除条目失败，请重试。",
-      "hideOriginal": "Hide original",
-      "showOriginal": "Show original"
+      "hideOriginal": "隐藏原文",
+      "showOriginal": "显示原文"
     },
     "debug": {
       "title": "调试",
@@ -546,7 +546,7 @@
       "soundTheme": {
         "label": "声音主题",
         "description": "选择录制开始和停止反馈的声音主题",
-        "preview": "Preview sound theme (plays start then stop)"
+        "preview": "预览声音主题（播放开始和停止声音）"
       },
       "wordCorrectionThreshold": {
         "title": "词汇修正阈值",
@@ -659,8 +659,8 @@
     "yes": "是",
     "no": "否",
     "noOptionsFound": "未找到选项",
-    "copyToClipboard": "Copy to clipboard",
-    "search": "Search..."
+    "copyToClipboard": "复制到剪贴板",
+    "search": "搜索..."
   },
   "accessibility": {
     "permissionsRequired": "需要辅助功能权限",

--- a/src/lib/utils/modelTranslation.ts
+++ b/src/lib/utils/modelTranslation.ts
@@ -22,28 +22,6 @@ export function getTranslatedModelName(
   return translated !== "" ? translated : provider.name;
 }
 
-/**
- * Get the translated description for a provider
- * @param provider - The STT provider info object
- * @param t - The translation function from useTranslation
- * @returns The translated provider description, or the original description if no translation exists
- */
-export function getTranslatedModelDescription(
-  provider: SttProviderInfo,
-  t: TFunction,
-): string {
-  if (provider.backend.type === "Local" && provider.backend.is_custom) {
-    return t("onboarding.customModelDescription");
-  }
-  if (provider.backend.type === "Cloud") {
-    const cloudKey = `onboarding.cloud.${provider.id}.description`;
-    const cloudTranslated = t(cloudKey, { defaultValue: "" });
-    return cloudTranslated !== "" ? cloudTranslated : provider.description;
-  }
-  const translationKey = `onboarding.models.${provider.id}.description`;
-  const translated = t(translationKey, { defaultValue: "" });
-  return translated !== "" ? translated : provider.description;
-}
 
 export function getLanguageDisplayText(
   supportedLanguages: string[],


### PR DESCRIPTION
## Summary
- Move hardcoded model descriptions from Rust backend to i18n translation system
- Backend now returns translation keys for all model descriptions
- Update all 21 translation files with model description translations
- Simplify frontend by removing translation helper function that's no longer needed

## Test plan
- [ ] Verify model descriptions display correctly in onboarding flow
- [ ] Check that all model cards show proper descriptions in all supported languages
- [ ] Confirm cloud provider cards render without errors