### PR TITLE
fix: prevent dock icon flash on startup and overlay creation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -455,6 +455,20 @@ pub fn run(cli_args: CliArgs) {
         ))
         .manage(cli_args.clone())
         .setup(move |app| {
+            // Build the main window during setup so startup window creation follows
+            // the same lifecycle as Handy and does not flash the dock icon on macOS.
+            tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("/".into()))
+                .title("Handless")
+                .inner_size(900.0, 587.0)
+                .min_inner_size(900.0, 587.0)
+                .resizable(true)
+                .maximizable(false)
+                .visible(false)
+                .transparent(true)
+                .title_bar_style(tauri::TitleBarStyle::Overlay)
+                .hidden_title(true)
+                .build()?;
+
             let mut settings = get_settings(&app.handle());
 
             // CLI --debug flag overrides debug_mode and log level (runtime-only, not persisted)

--- a/src-tauri/src/managers/history.rs
+++ b/src-tauri/src/managers/history.rs
@@ -407,13 +407,14 @@ impl HistoryManager {
     pub fn get_history_entries_page(&self, limit: i64, cursor: Option<i64>) -> Result<HistoryPage> {
         let conn = self.get_connection()?;
 
-        let total_count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM transcription_history",
-            [],
-            |row| row.get(0),
-        )?;
+        let total_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM transcription_history", [], |row| {
+                row.get(0)
+            })?;
 
-        let (query, cursor_params): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = if cursor.is_some() {
+        let (query, cursor_params): (&str, Vec<Box<dyn rusqlite::types::ToSql>>) = if cursor
+            .is_some()
+        {
             (
                 "SELECT id, file_name, timestamp, saved, title, transcription_text, post_processed_text, post_process_prompt
                  FROM transcription_history WHERE id < ?1 ORDER BY id DESC LIMIT ?2",

--- a/src-tauri/src/managers/model.rs
+++ b/src-tauri/src/managers/model.rs
@@ -295,7 +295,8 @@ impl ModelManager {
             ModelInfo {
                 id: "moonshine-tiny-streaming-en".to_string(),
                 name: "Moonshine V2 Tiny".to_string(),
-                description: "onboarding.models.moonshine-tiny-streaming-en.description".to_string(),
+                description: "onboarding.models.moonshine-tiny-streaming-en.description"
+                    .to_string(),
                 filename: "moonshine-tiny-streaming-en".to_string(),
                 url: Some(
                     "https://blob.handy.computer/moonshine-tiny-streaming-en.tar.gz".to_string(),
@@ -320,7 +321,8 @@ impl ModelManager {
             ModelInfo {
                 id: "moonshine-small-streaming-en".to_string(),
                 name: "Moonshine V2 Small".to_string(),
-                description: "onboarding.models.moonshine-small-streaming-en.description".to_string(),
+                description: "onboarding.models.moonshine-small-streaming-en.description"
+                    .to_string(),
                 filename: "moonshine-small-streaming-en".to_string(),
                 url: Some(
                     "https://blob.handy.computer/moonshine-small-streaming-en.tar.gz".to_string(),
@@ -345,7 +347,8 @@ impl ModelManager {
             ModelInfo {
                 id: "moonshine-medium-streaming-en".to_string(),
                 name: "Moonshine V2 Medium".to_string(),
-                description: "onboarding.models.moonshine-medium-streaming-en.description".to_string(),
+                description: "onboarding.models.moonshine-medium-streaming-en.description"
+                    .to_string(),
                 filename: "moonshine-medium-streaming-en".to_string(),
                 url: Some(
                     "https://blob.handy.computer/moonshine-medium-streaming-en.tar.gz".to_string(),

--- a/src-tauri/src/overlay.rs
+++ b/src-tauri/src/overlay.rs
@@ -269,9 +269,15 @@ pub fn create_recording_overlay(app_handle: &AppHandle) {
             }))
             .has_shadow(false)
             .transparent(true)
-            .no_activate(true)
             .corner_radius(0.0)
-            .with_window(|w| w.decorations(false).transparent(true))
+            // Build the backing window hidden so panel creation does not need
+            // to temporarily flip the app activation policy and flash the dock icon.
+            .with_window(|w| {
+                w.decorations(false)
+                    .transparent(true)
+                    .visible(false)
+                    .focused(false)
+            })
             .collection_behavior(
                 CollectionBehavior::new()
                     .can_join_all_spaces()

--- a/src-tauri/src/post_process/commands.rs
+++ b/src-tauri/src/post_process/commands.rs
@@ -225,8 +225,7 @@ pub fn delete_post_process_prompt(app: AppHandle, id: String) -> Result<(), Stri
     // Update any bindings that referenced the deleted prompt
     for binding in settings.bindings.values_mut() {
         if binding.post_process_prompt_id.as_ref() == Some(&id) {
-            binding.post_process_prompt_id =
-                settings.post_process_selected_prompt_id.clone();
+            binding.post_process_prompt_id = settings.post_process_selected_prompt_id.clone();
         }
     }
 
@@ -236,10 +235,7 @@ pub fn delete_post_process_prompt(app: AppHandle, id: String) -> Result<(), Stri
 
 #[tauri::command]
 #[specta::specta]
-pub fn set_post_process_selected_prompt(
-    app: AppHandle,
-    id: Option<String>,
-) -> Result<(), String> {
+pub fn set_post_process_selected_prompt(app: AppHandle, id: Option<String>) -> Result<(), String> {
     let mut settings = settings::get_settings(&app);
 
     // Verify the prompt exists when a prompt is selected

--- a/src-tauri/src/post_process/process.rs
+++ b/src-tauri/src/post_process/process.rs
@@ -94,7 +94,9 @@ pub async fn post_process_transcription(
 
     // Skip post-processing if the provider is not verified (except Apple Intelligence)
     if provider.id != "apple_intelligence"
-        && !settings.post_process_verified_providers.contains(&provider.id)
+        && !settings
+            .post_process_verified_providers
+            .contains(&provider.id)
     {
         debug!(
             "Post-processing skipped because provider '{}' is not verified",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,22 +11,7 @@
   },
   "app": {
     "macOSPrivateApi": true,
-    "windows": [
-      {
-        "label": "main",
-        "title": "Handless",
-        "width": 900,
-        "height": 587,
-        "minWidth": 900,
-        "minHeight": 587,
-        "resizable": true,
-        "maximizable": false,
-        "visible": false,
-        "transparent": true,
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null,
       "assetProtocol": {


### PR DESCRIPTION
## Summary
- Move main window creation from `tauri.conf.json` to `setup()` so it follows the same lifecycle as the overlay and avoids flashing the dock icon on macOS
- Build the overlay backing window hidden with `focused(false)` to prevent activation policy flips that cause dock icon flash
- Includes minor rustfmt formatting adjustments in `history.rs`, `model.rs`, `commands.rs`, and `process.rs`

## Test plan
- [ ] Launch the app and verify the dock icon does not flash during startup
- [ ] Trigger a recording and verify the overlay appears without dock icon flash
- [ ] Verify the main window opens correctly with expected dimensions and title bar style
- [ ] Verify the overlay still displays and hides correctly during recording