### PR TITLE
fix: gate macOS-only window builder methods behind cfg

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -457,17 +457,24 @@ pub fn run(cli_args: CliArgs) {
         .setup(move |app| {
             // Build the main window during setup so startup window creation follows
             // the same lifecycle as Handy and does not flash the dock icon on macOS.
-            tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("/".into()))
-                .title("Handless")
-                .inner_size(900.0, 587.0)
-                .min_inner_size(900.0, 587.0)
-                .resizable(true)
-                .maximizable(false)
-                .visible(false)
-                .transparent(true)
-                .title_bar_style(tauri::TitleBarStyle::Overlay)
-                .hidden_title(true)
-                .build()?;
+            let mut builder =
+                tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("/".into()))
+                    .title("Handless")
+                    .inner_size(900.0, 587.0)
+                    .min_inner_size(900.0, 587.0)
+                    .resizable(true)
+                    .maximizable(false)
+                    .visible(false)
+                    .transparent(true);
+
+            #[cfg(target_os = "macos")]
+            {
+                builder = builder
+                    .title_bar_style(tauri::TitleBarStyle::Overlay)
+                    .hidden_title(true);
+            }
+
+            builder.build()?;
 
             let mut settings = get_settings(&app.handle());
 


### PR DESCRIPTION
## Summary
- `title_bar_style` and `hidden_title` on `WebviewWindowBuilder` are `#[cfg(target_os = "macos")]` — the previous PR (#98) called them unconditionally, failing CI on Linux
- Split the builder chain so these calls are conditionally compiled

## Test plan
- [ ] CI passes on Linux (rust-tests job)
- [ ] App still launches correctly on macOS with overlay title bar