### PR TITLE
refactor: unify post-processing into single code path

### DIFF
--- a/src-tauri/src/post_process/client.rs
+++ b/src-tauri/src/post_process/client.rs
@@ -101,27 +101,15 @@ fn create_client(provider: &PostProcessProvider, api_key: &str) -> Result<reqwes
         .map_err(|e| format!("Failed to build HTTP client: {}", e))
 }
 
-/// Send a chat completion request to an OpenAI-compatible API
-/// Returns Ok(Some(content)) on success, Ok(None) if response has no content,
-/// or Err on actual errors (HTTP, parsing, etc.)
+/// Send a chat completion request to an OpenAI-compatible API.
+/// Always uses system + user message structure.
+/// When json_schema is provided, includes response_format for structured outputs.
 pub async fn send_chat_completion(
     provider: &PostProcessProvider,
     api_key: String,
     model: &str,
-    prompt: String,
-) -> Result<(Option<String>, Option<Usage>), String> {
-    send_chat_completion_with_schema(provider, api_key, model, prompt, None, None).await
-}
-
-/// Send a chat completion request with structured output support
-/// When json_schema is provided, uses structured outputs mode
-/// system_prompt is used as the system message when provided
-pub async fn send_chat_completion_with_schema(
-    provider: &PostProcessProvider,
-    api_key: String,
-    model: &str,
     user_content: String,
-    system_prompt: Option<String>,
+    system_prompt: String,
     json_schema: Option<Value>,
 ) -> Result<(Option<String>, Option<Usage>), String> {
     let base_url = provider.base_url.trim_end_matches('/');
@@ -131,22 +119,16 @@ pub async fn send_chat_completion_with_schema(
 
     let client = create_client(provider, &api_key)?;
 
-    // Build messages vector
-    let mut messages = Vec::new();
-
-    // Add system prompt if provided
-    if let Some(system) = system_prompt {
-        messages.push(ChatMessage {
+    let messages = vec![
+        ChatMessage {
             role: "system".to_string(),
-            content: system,
-        });
-    }
-
-    // Add user message
-    messages.push(ChatMessage {
-        role: "user".to_string(),
-        content: user_content,
-    });
+            content: system_prompt,
+        },
+        ChatMessage {
+            role: "user".to_string(),
+            content: user_content,
+        },
+    ];
 
     // Build response_format if schema is provided
     let response_format = json_schema.map(|schema| ResponseFormat {

--- a/src-tauri/src/post_process/process.rs
+++ b/src-tauri/src/post_process/process.rs
@@ -2,7 +2,7 @@
 use crate::apple_intelligence;
 use crate::post_process::client::Usage;
 use crate::settings::{AppSettings, APPLE_INTELLIGENCE_PROVIDER_ID};
-use log::{debug, error, warn};
+use log::{debug, error};
 use serde::Serialize;
 use std::time::Instant;
 
@@ -48,18 +48,6 @@ fn strip_invisible_chars(s: &str) -> String {
     s.replace(['\u{200B}', '\u{200C}', '\u{200D}', '\u{FEFF}'], "")
 }
 
-/// Build a system prompt from the user's prompt template.
-/// Removes the `${output}` placeholder and any preceding "Transcript:" label,
-/// since the transcription is sent separately as the user message.
-fn build_system_prompt(prompt_template: &str) -> String {
-    let without_placeholder = prompt_template.replace("${output}", "");
-    without_placeholder
-        .trim_end()
-        .trim_end_matches("Transcript:")
-        .trim()
-        .to_string()
-}
-
 pub async fn post_process_transcription(
     settings: &AppSettings,
     transcription: &str,
@@ -93,7 +81,7 @@ pub async fn post_process_transcription(
     }
 
     // Skip post-processing if the provider is not verified (except Apple Intelligence)
-    if provider.id != "apple_intelligence"
+    if provider.id != APPLE_INTELLIGENCE_PROVIDER_ID
         && !settings
             .post_process_verified_providers
             .contains(&provider.id)
@@ -136,59 +124,58 @@ pub async fn post_process_transcription(
         .cloned()
         .unwrap_or_default();
 
-    if provider.supports_structured_output {
-        debug!("Using structured outputs for provider '{}'", provider.id);
+    let system_prompt = prompt.trim().to_string();
+    let user_content = format!("Transcript: {}", transcription);
 
-        let system_prompt = build_system_prompt(&prompt);
-        let user_content = format!("Transcript: {}", transcription);
-
-        // Handle Apple Intelligence separately since it uses native Swift APIs
-        if provider.id == APPLE_INTELLIGENCE_PROVIDER_ID {
-            #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-            {
-                if !apple_intelligence::check_apple_intelligence_availability() {
-                    debug!(
-                        "Apple Intelligence selected but not currently available on this device"
-                    );
-                    return None;
-                }
-
-                let token_limit = model.trim().parse::<i32>().unwrap_or(0);
-                let start = Instant::now();
-                return match apple_intelligence::process_text_with_system_prompt(
-                    &system_prompt,
-                    &user_content,
-                    token_limit,
-                ) {
-                    Ok(result) => {
-                        if result.trim().is_empty() {
-                            debug!("Apple Intelligence returned an empty response");
-                            None
-                        } else {
-                            let result = strip_invisible_chars(&result);
-                            debug!(
-                                "Apple Intelligence post-processing succeeded. Output length: {} chars",
-                                result.len()
-                            );
-                            Some(PostProcessResult::new(result, start, None, model))
-                        }
-                    }
-                    Err(err) => {
-                        error!("Apple Intelligence post-processing failed: {}", err);
-                        None
-                    }
-                };
-            }
-
-            #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-            {
-                debug!("Apple Intelligence provider selected on unsupported platform");
+    // Handle Apple Intelligence separately since it uses native Swift APIs
+    if provider.id == APPLE_INTELLIGENCE_PROVIDER_ID {
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        {
+            if !apple_intelligence::check_apple_intelligence_availability() {
+                debug!(
+                    "Apple Intelligence selected but not currently available on this device"
+                );
                 return None;
             }
+
+            let token_limit = model.trim().parse::<i32>().unwrap_or(0);
+            let start = Instant::now();
+            return match apple_intelligence::process_text_with_system_prompt(
+                &system_prompt,
+                &user_content,
+                token_limit,
+            ) {
+                Ok(result) => {
+                    if result.trim().is_empty() {
+                        debug!("Apple Intelligence returned an empty response");
+                        None
+                    } else {
+                        let result = strip_invisible_chars(&result);
+                        debug!(
+                            "Apple Intelligence post-processing succeeded. Output length: {} chars",
+                            result.len()
+                        );
+                        Some(PostProcessResult::new(result, start, None, model))
+                    }
+                }
+                Err(err) => {
+                    error!("Apple Intelligence post-processing failed: {}", err);
+                    None
+                }
+            };
         }
 
-        // Define JSON schema for transcription output
-        let json_schema = serde_json::json!({
+        #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+        {
+            debug!("Apple Intelligence provider selected on unsupported platform");
+            return None;
+        }
+    }
+
+    // Build JSON schema for structured output when supported by the provider
+    let json_schema = if provider.supports_structured_output {
+        debug!("Using structured outputs for provider '{}'", provider.id);
+        Some(serde_json::json!({
             "type": "object",
             "properties": {
                 (TRANSCRIPTION_FIELD): {
@@ -198,33 +185,32 @@ pub async fn post_process_transcription(
             },
             "required": [TRANSCRIPTION_FIELD],
             "additionalProperties": false
-        });
+        }))
+    } else {
+        None
+    };
+    let requested_structured = json_schema.is_some();
 
-        let start = Instant::now();
-        match crate::post_process::client::send_chat_completion_with_schema(
-            &provider,
-            api_key.clone(),
-            &model,
-            user_content,
-            Some(system_prompt),
-            Some(json_schema),
-        )
-        .await
-        {
-            Ok((Some(content), usage)) => {
-                // Parse the JSON response to extract the transcription field
-                let text = match serde_json::from_str::<serde_json::Value>(&content) {
+    let start = Instant::now();
+    match crate::post_process::client::send_chat_completion(
+        &provider,
+        api_key,
+        &model,
+        user_content,
+        system_prompt,
+        json_schema,
+    )
+    .await
+    {
+        Ok((Some(content), usage)) => {
+            // If structured output was requested, parse the JSON response
+            let text = if requested_structured {
+                match serde_json::from_str::<serde_json::Value>(&content) {
                     Ok(json) => {
                         if let Some(transcription_value) =
                             json.get(TRANSCRIPTION_FIELD).and_then(|t| t.as_str())
                         {
-                            let result = strip_invisible_chars(transcription_value);
-                            debug!(
-                                "Structured output post-processing succeeded for provider '{}'. Output length: {} chars",
-                                provider.id,
-                                result.len()
-                            );
-                            result
+                            strip_invisible_chars(transcription_value)
                         } else {
                             error!("Structured output response missing 'transcription' field");
                             strip_invisible_chars(&content)
@@ -237,54 +223,17 @@ pub async fn post_process_transcription(
                         );
                         strip_invisible_chars(&content)
                     }
-                };
-                return Some(PostProcessResult::new(text, start, usage.as_ref(), model));
-            }
-            Ok((None, _)) => {
-                error!("LLM API response has no content");
-                return None;
-            }
-            Err(e) => {
-                warn!(
-                    "Structured output failed for provider '{}': {}. Falling back to legacy mode.",
-                    provider.id, e
-                );
-                // Fall through to legacy mode below
-            }
-        }
-    }
+                }
+            } else {
+                strip_invisible_chars(&content)
+            };
 
-    // Legacy mode: Replace ${output} variable in the prompt with the actual text,
-    // or append the transcript at the end if no placeholder is present.
-    let processed_prompt = if prompt.contains("${output}") {
-        prompt.replace("${output}", transcription)
-    } else {
-        format!("{}\n\nTranscript: {}", prompt.trim_end(), transcription)
-    };
-    debug!("Processed prompt length: {} chars", processed_prompt.len());
-
-    let start = Instant::now();
-    match crate::post_process::client::send_chat_completion(
-        &provider,
-        api_key,
-        &model,
-        processed_prompt,
-    )
-    .await
-    {
-        Ok((Some(content), usage)) => {
-            let content = strip_invisible_chars(&content);
             debug!(
                 "LLM post-processing succeeded for provider '{}'. Output length: {} chars",
                 provider.id,
-                content.len()
+                text.len()
             );
-            Some(PostProcessResult::new(
-                content,
-                start,
-                usage.as_ref(),
-                model,
-            ))
+            Some(PostProcessResult::new(text, start, usage.as_ref(), model))
         }
         Ok((None, _)) => {
             error!("LLM API response has no content");
@@ -292,9 +241,8 @@ pub async fn post_process_transcription(
         }
         Err(e) => {
             error!(
-                "LLM post-processing failed for provider '{}': {}. Falling back to original transcription.",
-                provider.id,
-                e
+                "LLM post-processing failed for provider '{}': {}",
+                provider.id, e
             );
             None
         }


### PR DESCRIPTION
## Summary
- Remove legacy `${output}` template mode and fallback retry logic, routing all providers through the same system+user message API call
- Remove unused `send_chat_completion` wrapper; rename `send_chat_completion_with_schema` → `send_chat_completion` and make `system_prompt` non-optional
- Inline trivial `build_system_prompt`, use `APPLE_INTELLIGENCE_PROVIDER_ID` constant consistently, and key response parsing off whether structured output was actually requested

## Test plan
- [ ] Verify post-processing works with a structured-output provider (e.g. OpenAI)
- [ ] Verify post-processing works with a non-structured-output provider (e.g. OpenRouter)
- [ ] Verify Apple Intelligence path still works on supported hardware
- [ ] Confirm `cargo check` passes cleanly