### PR TITLE
fix: replace mic selector drag handle icon with ArrowsDownUp

### DIFF
--- a/src/components/settings/MicrophoneSelector.tsx
+++ b/src/components/settings/MicrophoneSelector.tsx
@@ -16,7 +16,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { DotsSixVertical, MicrophoneSlash, X } from "@phosphor-icons/react";
+import { ArrowsDownUp, MicrophoneSlash, X } from "@phosphor-icons/react";
 import { SettingContainer } from "../ui/SettingContainer";
 import { useSettings } from "../../hooks/useSettings";
 
@@ -65,7 +65,7 @@ const SortableItem: React.FC<SortableItemProps> = ({
         {...attributes}
         {...listeners}
       >
-        <DotsSixVertical className="w-3.5 h-3.5" />
+        <ArrowsDownUp className="w-3.5 h-3.5" />
       </button>
       <span className="truncate flex-1">{name}</span>
       {isActive && (


### PR DESCRIPTION
## Summary
- Replace `DotsSixVertical` icon with `ArrowsDownUp` for microphone reorder drag handles
- Clearly communicates drag-to-reorder functionality instead of ambiguous dot grid

## Test plan
- [ ] Run dev server and navigate to General settings
- [ ] Verify microphone items show vertical up/down arrows as drag handles
- [ ] Verify drag-and-drop reordering still works