### PR TITLE
fix: reduce icon jitter during settings page stagger animation

### DIFF
--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -258,8 +258,8 @@ export const HistorySettings: React.FC = () => {
       animate="animate"
     >
       <h1 className="sr-only">{t("sidebar.history")}</h1>
-      <motion.div variants={staggerItem}>{retentionSection}</motion.div>
-      <motion.div className="space-y-1.5" variants={staggerItem}>
+      <motion.div variants={staggerItem} style={{ willChange: "transform" }}>{retentionSection}</motion.div>
+      <motion.div className="space-y-1.5" variants={staggerItem} style={{ willChange: "transform" }}>
         <div className="px-3 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <h2 className="text-xs font-medium text-muted uppercase tracking-wide">

--- a/src/components/settings/models/ModelsSettings.tsx
+++ b/src/components/settings/models/ModelsSettings.tsx
@@ -20,7 +20,7 @@ export const ModelsSettings: React.FC = () => {
       initial="initial"
       animate="animate"
     >
-      <motion.div className="mb-4" variants={staggerItem}>
+      <motion.div className="mb-4" variants={staggerItem} style={{ willChange: "transform" }}>
         <h1 className="text-xl font-semibold mb-2">
           {t("settings.models.title")}
         </h1>
@@ -29,7 +29,7 @@ export const ModelsSettings: React.FC = () => {
         </p>
       </motion.div>
 
-      <motion.div variants={staggerItem}>
+      <motion.div variants={staggerItem} style={{ willChange: "transform" }}>
         <div role="tablist" className="flex gap-1 border-b border-muted/20 mb-4">
           <button
             type="button"

--- a/src/components/ui/SettingsGroup.tsx
+++ b/src/components/ui/SettingsGroup.tsx
@@ -33,7 +33,7 @@ export const SettingsGroup: React.FC<SettingsGroupProps> = ({
       >
         <div className="divide-y divide-glass-border">
           {React.Children.map(children, (child, i) => (
-            <motion.div key={i} variants={staggerItem}>
+            <motion.div key={i} variants={staggerItem} style={{ willChange: "transform" }}>
               {child}
             </motion.div>
           ))}


### PR DESCRIPTION
## Summary
- Add `will-change: transform` to stagger item `motion.div` wrappers in `SettingsGroup`, `ModelsSettings`, and `HistorySettings`
- Pre-promotes each animated row to its own GPU compositing layer so SVG icons are stably rasterized before the `y: 6 → y: 0` entry animation begins
- Follows the same approach used in #102 for the sidebar layout animation jitter

## Test plan
- [ ] Switch between sidebar sections — icons in the newly rendered page should not jitter on entry
- [ ] Verify all pages: General, Shortcuts, Models, Post-processing, History, Advanced, About
- [ ] Check that the stagger animation itself still looks correct (rows should still fade/slide in)