### PR TITLE
fix: remove invalid eslint-disable directive

### DIFF
--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -233,7 +233,6 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
     if (!expandedPrompt || isCreating) return;
     setDraftName(expandedPrompt.name);
     setDraftText(expandedPrompt.prompt);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedId]);
 
   const handleToggle = (promptId: string) => {


### PR DESCRIPTION
## Summary
- Remove `eslint-disable-next-line react-hooks/exhaustive-deps` comment that referenced a rule not configured in this project, causing a lint error

## Test plan
- [x] `npm run lint` passes cleanly