### PR TITLE
fix: improve post-processing prompts UX

### DIFF
--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -119,7 +119,7 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
               <FieldAlignmentSpacer>
                 {state.isVerified && (
                   <Check
-                    className="w-4 h-4 text-green-500"
+                    className="w-4 h-4 text-green-400"
                     aria-label={t("settings.postProcessing.api.verified")}
                   />
                 )}
@@ -212,6 +212,53 @@ function usePromptShortcuts(
   }, [bindings, osType]);
 }
 
+interface PromptFieldsProps {
+  name: string;
+  text: string;
+  onNameChange: (value: string) => void;
+  onTextChange: (value: string) => void;
+  disabled?: boolean;
+  autoFocus?: boolean;
+}
+
+const PromptFields: React.FC<PromptFieldsProps> = ({
+  name,
+  text,
+  onNameChange,
+  onTextChange,
+  disabled,
+  autoFocus,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <>
+      <div>
+        <Input
+          type="text"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder={t("settings.postProcessing.prompts.promptLabelPlaceholder")}
+          disabled={disabled}
+          className="rounded-b-none border-b-0 text-sm font-semibold"
+          autoFocus={autoFocus}
+        />
+        <Textarea
+          value={text}
+          onChange={(e) => onTextChange(e.target.value)}
+          placeholder={t("settings.postProcessing.prompts.promptInstructionsPlaceholder")}
+          disabled={disabled}
+          className="min-h-[200px] rounded-t-none"
+        />
+      </div>
+      <p className="text-xs text-muted/70">
+        {disabled
+          ? t("settings.postProcessing.prompts.builtInReadOnly")
+          : t("settings.postProcessing.prompts.promptTip")}
+      </p>
+    </>
+  );
+};
+
 const PostProcessingSettingsPromptsComponent: React.FC = () => {
   const { t } = useTranslation();
   const { getSetting, refreshSettings } = useSettings();
@@ -221,6 +268,8 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
   const isCreating = expandedId === CREATING_ID;
   const [draftName, setDraftName] = useState("");
   const [draftText, setDraftText] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   const prompts = getSetting("post_process_prompts") || [];
   const bindings = (getSetting("bindings") || {}) as Record<string, ShortcutBinding>;
@@ -236,21 +285,26 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
   }, [expandedId]);
 
   const handleToggle = (promptId: string) => {
+    setFormError(null);
     setExpandedId((prev) => (prev === promptId ? null : promptId));
   };
 
   const handleStartCreate = () => {
+    setFormError(null);
     setExpandedId(CREATING_ID);
     setDraftName("");
     setDraftText("");
   };
 
   const handleCancelCreate = () => {
+    setFormError(null);
     setExpandedId(null);
   };
 
   const handleCreatePrompt = async () => {
     if (!draftName.trim() || !draftText.trim()) return;
+    setIsSubmitting(true);
+    setFormError(null);
     try {
       const result = await commands.addPostProcessPrompt(
         draftName.trim(),
@@ -262,11 +316,16 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
       }
     } catch (error) {
       console.error("Failed to create prompt:", error);
+      setFormError(t("settings.postProcessing.prompts.errorCreate"));
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   const handleUpdatePrompt = async () => {
     if (!expandedId || !draftName.trim() || !draftText.trim()) return;
+    setIsSubmitting(true);
+    setFormError(null);
     try {
       await commands.updatePostProcessPrompt(
         expandedId,
@@ -276,45 +335,27 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
       await refreshSettings();
     } catch (error) {
       console.error("Failed to update prompt:", error);
+      setFormError(t("settings.postProcessing.prompts.errorUpdate"));
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   const handleDeletePrompt = async (promptId: string) => {
     if (!promptId) return;
+    setIsSubmitting(true);
+    setFormError(null);
     try {
       await commands.deletePostProcessPrompt(promptId);
       await refreshSettings();
       if (expandedId === promptId) setExpandedId(null);
     } catch (error) {
       console.error("Failed to delete prompt:", error);
+      setFormError(t("settings.postProcessing.prompts.errorDelete"));
+    } finally {
+      setIsSubmitting(false);
     }
   };
-
-  const promptFields = (options?: { disabled?: boolean; autoFocus?: boolean }) => (
-    <>
-      <div>
-        <Input
-          type="text"
-          value={draftName}
-          onChange={(e) => setDraftName(e.target.value)}
-          placeholder={t("settings.postProcessing.prompts.promptLabelPlaceholder")}
-          disabled={options?.disabled}
-          className="rounded-b-none border-b-0 text-sm font-semibold"
-          autoFocus={options?.autoFocus}
-        />
-        <Textarea
-          value={draftText}
-          onChange={(e) => setDraftText(e.target.value)}
-          placeholder={t("settings.postProcessing.prompts.promptInstructionsPlaceholder")}
-          disabled={options?.disabled}
-          className="min-h-[200px] rounded-t-none"
-        />
-      </div>
-      <p className="text-xs text-muted/70">
-        {t("settings.postProcessing.prompts.promptTip")}
-      </p>
-    </>
-  );
 
   return (
     <div className="px-3 py-1.5">
@@ -341,9 +382,19 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
               {/* Header row — always visible */}
               <div
                 className={`flex items-center gap-2 ${isExpanded ? "cursor-pointer" : ""}`}
+                role={isExpanded ? "button" : undefined}
+                tabIndex={isExpanded ? 0 : undefined}
+                aria-expanded={isExpanded}
                 onClick={() => {
                   if (!isExpanded) return;
                   handleToggle(prompt.id);
+                }}
+                onKeyDown={(e) => {
+                  if (!isExpanded) return;
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleToggle(prompt.id);
+                  }
                 }}
               >
                 <motion.div
@@ -364,16 +415,16 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
                   )}
                 </div>
                 <div className="flex items-center gap-1.5 shrink-0">
-                  {isBuiltIn && (
-                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                      {t("settings.postProcessing.prompts.builtIn")}
-                    </Badge>
-                  )}
                   {shortcuts.map((s) => (
                     <Badge key={s.id} variant="outline" className="text-[10px] px-1.5 py-0 font-mono">
                       {s.shortcut}
                     </Badge>
                   ))}
+                  {isBuiltIn && (
+                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                      {t("settings.postProcessing.prompts.builtIn")}
+                    </Badge>
+                  )}
                 </div>
               </div>
 
@@ -391,34 +442,48 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
               >
                 <div className="overflow-hidden min-h-0">
                   <div className="space-y-3 pt-2">
-                    {promptFields({ disabled: isBuiltIn })}
+                    <PromptFields
+                      name={draftName}
+                      text={draftText}
+                      onNameChange={setDraftName}
+                      onTextChange={setDraftText}
+                      disabled={isBuiltIn}
+                    />
 
                     {!isBuiltIn && (
-                      <div className="flex gap-2 pt-1">
-                        <Button
-                          onClick={handleUpdatePrompt}
-                          variant="default"
-                          size="default"
-                          disabled={
-                            !draftName.trim() ||
-                            !draftText.trim() ||
-                            !isDirty
-                          }
-                        >
-                          {t(
-                            "settings.postProcessing.prompts.updatePrompt",
-                          )}
-                        </Button>
-                        <Button
-                          onClick={() => handleDeletePrompt(prompt.id)}
-                          variant="secondary"
-                          size="default"
-                          disabled={prompts.length <= 1}
-                        >
-                          {t(
-                            "settings.postProcessing.prompts.deletePrompt",
-                          )}
-                        </Button>
+                      <div className="space-y-2">
+                        <div className="flex gap-2 pt-1">
+                          <Button
+                            onClick={handleUpdatePrompt}
+                            variant="default"
+                            size="default"
+                            disabled={
+                              isSubmitting ||
+                              !draftName.trim() ||
+                              !draftText.trim() ||
+                              !isDirty
+                            }
+                          >
+                            {t(
+                              "settings.postProcessing.prompts.updatePrompt",
+                            )}
+                          </Button>
+                          <Button
+                            onClick={() => handleDeletePrompt(prompt.id)}
+                            variant="danger-ghost"
+                            size="default"
+                            disabled={isSubmitting || prompts.length <= 1}
+                          >
+                            {t(
+                              "settings.postProcessing.prompts.deletePrompt",
+                            )}
+                          </Button>
+                        </div>
+                        {formError && isExpanded && (
+                          <Alert variant="destructive" contained>
+                            {formError}
+                          </Alert>
+                        )}
                       </div>
                     )}
                   </div>
@@ -432,23 +497,36 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
         {isCreating && (
           <SelectableCard active compact>
             <div className="space-y-3">
-              {promptFields({ autoFocus: true })}
-              <div className="flex gap-2 pt-1">
-                <Button
-                  onClick={handleCreatePrompt}
-                  variant="default"
-                  size="default"
-                  disabled={!draftName.trim() || !draftText.trim()}
-                >
-                  {t("settings.postProcessing.prompts.createPrompt")}
-                </Button>
-                <Button
-                  onClick={handleCancelCreate}
-                  variant="secondary"
-                  size="default"
-                >
-                  {t("settings.postProcessing.prompts.cancel")}
-                </Button>
+              <PromptFields
+                name={draftName}
+                text={draftText}
+                onNameChange={setDraftName}
+                onTextChange={setDraftText}
+                autoFocus
+              />
+              <div className="space-y-2">
+                <div className="flex gap-2 pt-1">
+                  <Button
+                    onClick={handleCreatePrompt}
+                    variant="default"
+                    size="default"
+                    disabled={isSubmitting || !draftName.trim() || !draftText.trim()}
+                  >
+                    {t("settings.postProcessing.prompts.createPrompt")}
+                  </Button>
+                  <Button
+                    onClick={handleCancelCreate}
+                    variant="secondary"
+                    size="default"
+                  >
+                    {t("settings.postProcessing.prompts.cancel")}
+                  </Button>
+                </div>
+                {formError && (
+                  <Alert variant="destructive" contained>
+                    {formError}
+                  </Alert>
+                )}
               </div>
             </div>
           </SelectableCard>

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -405,13 +405,17 @@
         "promptLabelPlaceholder": "أدخل اسم المطالبة",
         "promptInstructions": "تعليمات المطالبة",
         "promptInstructionsPlaceholder": ".اكتب التعليمات المراد تشغيلها بعد التفريغ الصوتي. يتم إلحاق النص المفرغ تلقائياً",
-        "promptTip": "تلميح: يتم توفير النص المفرغ تلقائياً كمدخل للمطالبة.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "تحديث المطالبة",
         "deletePrompt": "حذف المطالبة",
         "createPrompt": "إنشاء",
         "cancel": "إلغاء",
-        "createFirst": ".انقر على 'إنشاء مطالبة جديدة' أعلاه لإنشاء أول مطالبة معالجة لاحقة لك",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Zadejte název promptu",
         "promptInstructions": "Instrukce promptu",
         "promptInstructionsPlaceholder": "Napište instrukce, které se mají spustit po přepisu. Přepis je automaticky připojen.",
-        "promptTip": "Tip: Přepsaný text je automaticky poskytnut jako vstup promptu.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Aktualizovat prompt",
         "deletePrompt": "Smazat prompt",
         "createPrompt": "Vytvořit",
         "cancel": "Zrušit",
-        "createFirst": "Klikněte nahoře na 'Vytvořit nový prompt' a vytvořte svůj první prompt pro následné zpracování.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Prompt-Namen eingeben",
         "promptInstructions": "Prompt-Anweisungen",
         "promptInstructionsPlaceholder": "Schreibe die Anweisungen, die nach der Transkription ausgeführt werden sollen. Das Transkript wird automatisch angehängt.",
-        "promptTip": "Tipp: Der transkribierte Text wird dem Prompt automatisch als Eingabe bereitgestellt.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Prompt aktualisieren",
         "deletePrompt": "Prompt löschen",
         "createPrompt": "Erstellen",
         "cancel": "Abbrechen",
-        "createFirst": "Klicke oben auf 'Neuen Prompt erstellen', um deinen ersten Nachbearbeitungs-Prompt zu erstellen.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Enter prompt name",
         "promptInstructions": "Prompt Instructions",
         "promptInstructionsPlaceholder": "Write the instructions to run after transcription. The transcript is automatically appended.",
-        "promptTip": "Tip: The transcribed text is automatically provided to the prompt as input.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Update Prompt",
         "deletePrompt": "Delete Prompt",
         "createPrompt": "Create",
         "cancel": "Cancel",
-        "createFirst": "Click 'New Prompt' above to create your first post-processing prompt.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Ingresa el nombre del prompt",
         "promptInstructions": "Instrucciones del Prompt",
         "promptInstructionsPlaceholder": "Escribe las instrucciones para ejecutar después de la transcripción. La transcripción se añade automáticamente.",
-        "promptTip": "Consejo: El texto transcrito se proporciona automáticamente como entrada al prompt.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Actualizar Prompt",
         "deletePrompt": "Eliminar Prompt",
         "createPrompt": "Crear",
         "cancel": "Cancelar",
-        "createFirst": "Haz clic en 'Crear Nuevo Prompt' arriba para crear tu primer prompt de post procesamiento.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Entrez le nom du prompt",
         "promptInstructions": "Instructions du prompt",
         "promptInstructionsPlaceholder": "Écrivez les instructions à exécuter après la transcription. La transcription est automatiquement ajoutée.",
-        "promptTip": "Astuce : Le texte transcrit est automatiquement fourni comme entrée au prompt.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Mettre à jour le prompt",
         "deletePrompt": "Supprimer le prompt",
         "createPrompt": "Créer",
         "cancel": "Annuler",
-        "createFirst": "Cliquez sur 'Créer un nouveau prompt' ci-dessus pour créer votre premier prompt de post-traitement.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Inserisci il nome del prompt",
         "promptInstructions": "Istruzioni del Prompt",
         "promptInstructionsPlaceholder": "Scrivi le istruzioni da eseguire dopo la trascrizione. La trascrizione viene aggiunta automaticamente.",
-        "promptTip": "Suggerimento: Il testo trascritto viene fornito automaticamente come input al prompt.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Aggiorna Prompt",
         "deletePrompt": "Elimina Prompt",
         "createPrompt": "Crea",
         "cancel": "Annulla",
-        "createFirst": "Clicca 'Crea un nuovo prompt' qui sopra per creare il tuo primo prompt di post-elaborazione.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "プロンプト名を入力",
         "promptInstructions": "プロンプトの指示",
         "promptInstructionsPlaceholder": "文字起こし後に実行する指示を記述します。文字起こしは自動的に追加されます。",
-        "promptTip": "ヒント：文字起こしテキストはプロンプトへの入力として自動的に提供されます。",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "プロンプトを更新",
         "deletePrompt": "プロンプトを削除",
         "createPrompt": "作成",
         "cancel": "キャンセル",
-        "createFirst": "上の「新しいプロンプトを作成」をクリックして、最初の後処理プロンプトを作成してください。",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "프롬프트 이름 입력",
         "promptInstructions": "프롬프트 지시사항",
         "promptInstructionsPlaceholder": "텍스트 변환 후 실행할 지시사항을 작성하세요. 텍스트 변환 결과는 자동으로 추가됩니다.",
-        "promptTip": "팁: 변환된 텍스트는 프롬프트에 입력으로 자동 제공됩니다.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "프롬프트 업데이트",
         "deletePrompt": "프롬프트 삭제",
         "createPrompt": "만들기",
         "cancel": "취소",
-        "createFirst": "첫 번째 후처리 프롬프트를 만들려면 위의 '새 프롬프트 만들기'를 클릭하세요.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Wpisz nazwę promptu",
         "promptInstructions": "Instrukcje promptu",
         "promptInstructionsPlaceholder": "Wpisz instrukcje do wykonania po transkrypcji. Transkrypcja jest automatycznie dołączana.",
-        "promptTip": "Wskazówka: Transkrybowany tekst jest automatycznie dostarczany jako dane wejściowe do promptu.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Zaktualizuj prompt",
         "deletePrompt": "Usuń prompt",
         "createPrompt": "Utwórz",
         "cancel": "Anuluj",
-        "createFirst": "Kliknij 'Utwórz nowy prompt' powyżej, aby utworzyć pierwszy prompt postprocessingu.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Digite o nome do prompt",
         "promptInstructions": "Instruções do Prompt",
         "promptInstructionsPlaceholder": "Escreva as instruções para executar após a transcrição. A transcrição é adicionada automaticamente.",
-        "promptTip": "Dica: O texto transcrito é fornecido automaticamente como entrada ao prompt.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Atualizar Prompt",
         "deletePrompt": "Excluir Prompt",
         "createPrompt": "Criar",
         "cancel": "Cancelar",
-        "createFirst": "Clique em 'Criar Novo Prompt' acima para criar seu primeiro prompt de pós-processamento.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Введите имя подсказки",
         "promptInstructions": "Оперативная инструкция",
         "promptInstructionsPlaceholder": "Напишите инструкции для запуска после транскрипции. Стенограмма добавляется автоматически.",
-        "promptTip": "Совет: Расшифрованный текст автоматически предоставляется как входные данные для промпта.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Обновить запрос",
         "deletePrompt": "Удалить подсказку",
         "createPrompt": "Создать",
         "cancel": "Отмена",
-        "createFirst": "Нажмите «Создать новое приглашение» выше, чтобы создать первое приглашение для постобработки.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Prompt adı girin",
         "promptInstructions": "Prompt Talimatları",
         "promptInstructionsPlaceholder": "Transkripsiyondan sonra çalıştırılacak talimatları yazın. Transkript otomatik olarak eklenir.",
-        "promptTip": "İpucu: Transkribe edilen metin otomatik olarak prompt'a giriş olarak sağlanır.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Promptu Güncelle",
         "deletePrompt": "Promptu Sil",
         "createPrompt": "Oluştur",
         "cancel": "İptal",
-        "createFirst": "İlk son işlem prompt'unuzu oluşturmak için yukarıdaki “Yeni Prompt Oluştur” seçeneğine tıklayın.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Введіть назву промпта",
         "promptInstructions": "Інструкції промпта",
         "promptInstructionsPlaceholder": "Напишіть інструкції для виконання після транскрипції. Транскрипція додається автоматично.",
-        "promptTip": "Порада: Транскрибований текст автоматично надається як вхідні дані для промпта.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Оновити промпт",
         "deletePrompt": "Видалити промпт",
         "createPrompt": "Створити",
         "cancel": "Скасувати",
-        "createFirst": "Натисніть «Створити новий промпт» вище, щоб створити ваш перший промпт постобробки.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "Nhập tên prompt",
         "promptInstructions": "Hướng dẫn Prompt",
         "promptInstructionsPlaceholder": "Viết hướng dẫn để chạy sau khi chuyển đổi. Bản ghi được tự động thêm vào.",
-        "promptTip": "Mẹo: Văn bản đã chuyển đổi được tự động cung cấp làm đầu vào cho prompt.",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "Cập nhật Prompt",
         "deletePrompt": "Xóa Prompt",
         "createPrompt": "Tạo",
         "cancel": "Hủy",
-        "createFirst": "Nhấn 'Tạo Prompt mới' ở trên để tạo prompt xử lý sau đầu tiên của bạn.",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "輸入提示詞名稱",
         "promptInstructions": "提示詞指令",
         "promptInstructionsPlaceholder": "撰寫轉錄後要執行的指令。轉錄內容會自動附加。",
-        "promptTip": "提示：轉錄文字會自動作為輸入提供給提示詞。",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "更新提示詞",
         "deletePrompt": "刪除提示詞",
         "createPrompt": "建立",
         "cancel": "取消",
-        "createFirst": "點選上方的「建立新提示詞」來建立您的第一個後處理提示詞",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -483,13 +483,17 @@
         "promptLabelPlaceholder": "输入提示词名称",
         "promptInstructions": "提示词指令",
         "promptInstructionsPlaceholder": "编写转录后要执行的指令。转录内容会自动追加。",
-        "promptTip": "提示：转录文本会自动作为输入提供给提示词。",
+        "promptTip": "Tip: Focus on formatting and correction style. The transcript is always appended automatically.",
         "updatePrompt": "更新提示词",
         "deletePrompt": "删除提示词",
         "createPrompt": "创建",
         "cancel": "取消",
-        "createFirst": "点击上方的「创建新提示词」来创建您的第一个后处理提示词。",
-        "builtIn": "Built-in"
+        "createFirst": "Use the button below to create your first prompt.",
+        "builtIn": "Built-in",
+        "builtInReadOnly": "Built-in prompts are read-only.",
+        "errorCreate": "Failed to create prompt. Please try again.",
+        "errorUpdate": "Failed to update prompt. Please try again.",
+        "errorDelete": "Failed to delete prompt. Please try again."
       }
     },
     "stats": {


### PR DESCRIPTION
## Summary
- Extract inline `promptFields` render function into a proper `PromptFields` component with typed props
- Add `isSubmitting` state to disable buttons during async create/update/delete operations
- Show user-visible error alerts (`formError`) when prompt operations fail
- Add `role`, `tabIndex`, `aria-expanded`, and keyboard handlers to expanded prompt headers for accessibility
- Change delete button variant to `danger-ghost` for clearer destructive action styling
- Add `builtInReadOnly` hint for built-in prompts, reorder badges (shortcuts before "Built-in")
- Update `promptTip` and `createFirst` copy; add error message i18n keys across all 18 locales

## Test plan
- [ ] Create a new prompt — verify button disables during submission and re-enables after
- [ ] Trigger a create/update/delete failure (e.g. disconnect network) — verify error alert appears
- [ ] Expand a prompt and use keyboard (Tab, Enter/Space) to collapse it
- [ ] Verify built-in prompts show "Built-in prompts are read-only." hint instead of the tip
- [ ] Verify delete button uses danger-ghost styling
- [ ] Check that switching between prompts clears any prior error