### PR TITLE
fix: make history action buttons discoverable

### DIFF
--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -390,7 +390,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = memo(
             </SimpleTooltip>
           )}
           {/* Other actions - visible on hover */}
-          <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+          <div className="flex items-center gap-0.5 opacity-30 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
             <SimpleTooltip content={t("settings.history.copyToClipboard")}>
               <button
                 onClick={handleCopyText}
@@ -421,7 +421,7 @@ const HistoryEntryComponent: React.FC<HistoryEntryProps> = memo(
         </div>
 
         {/* Text content */}
-        <p className="text-[13px] leading-snug text-text/90 select-text cursor-text">
+        <p className="text-[13px] leading-snug text-text/90 select-text cursor-text pr-28">
           {displayText}
         </p>
         {hasPostProcessed && (


### PR DESCRIPTION
## Summary
- Show history entry action buttons (copy, save, delete) at 30% opacity by default instead of fully hidden, so users know they exist without hovering
- Add right padding (`pr-28`) to transcript text to prevent buttons from overlaying multi-line entries

## Test plan
- [ ] Verify action buttons are subtly visible on history entries without hovering
- [ ] Verify buttons brighten to full opacity on hover
- [ ] Verify multi-line transcripts don't overlap with the action buttons
- [ ] Verify saved star still displays correctly for saved entries