### PR TITLE
fix: make clear stats confirm state visually distinct

### DIFF
--- a/src/components/settings/stats/StatsSettings.tsx
+++ b/src/components/settings/stats/StatsSettings.tsx
@@ -310,7 +310,11 @@ export const StatsSettings: React.FC = () => {
           <button
             onClick={handleClear}
             onBlur={() => setConfirmClear(false)}
-            className="flex items-center gap-1.5 text-xs text-muted/70 hover:text-red-400 transition-colors"
+            className={`flex items-center gap-1.5 text-xs transition-colors ${
+              confirmClear
+                ? "text-red-400 animate-shake"
+                : "text-muted/70 hover:text-red-400"
+            }`}
           >
             <Trash size={12} />
             {confirmClear

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,16 @@ export default {
         "glass-heavy": "var(--glass-blur-heavy)",
         "glass-light": "var(--glass-blur-light)",
       },
+      keyframes: {
+        shake: {
+          "0%, 100%": { transform: "translateX(0)" },
+          "20%, 60%": { transform: "translateX(-2px)" },
+          "40%, 80%": { transform: "translateX(2px)" },
+        },
+      },
+      animation: {
+        shake: "shake 0.3s ease-in-out",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- The "Clear stats" button previously only changed its label text on first click (confirm pattern), making it easy to miss the confirmation state
- Button now turns red (`text-red-400`) and plays a subtle shake animation when in confirmation mode
- Added `shake` keyframe animation to Tailwind config (2px horizontal oscillation, 0.3s)

## Test plan
- [ ] Open Settings → Stats with existing data
- [ ] Click "Clear stats" — verify button turns red and shakes briefly
- [ ] Click away (blur) — verify button resets to normal muted style
- [ ] Click "Clear stats" then click again to confirm — verify stats are cleared