### PR TITLE
fix: reorder stats tab before recordings

### DIFF
--- a/src/components/settings/history/HistorySettings.tsx
+++ b/src/components/settings/history/HistorySettings.tsx
@@ -61,11 +61,11 @@ export const HistorySettings: React.FC = () => {
   const { t } = useTranslation();
   const osType = useOsType();
   const shortcutDisplay = useTranscribeShortcut();
-  const [activeTab, setActiveTab] = useState<HistoryTab>("recordings");
+  const [activeTab, setActiveTab] = useState<HistoryTab>("stats");
   const tabs: TabItem[] = useMemo(
     () => [
-      { id: "recordings", label: t("settings.history.tabs.recordings") },
       { id: "stats", label: t("settings.history.tabs.stats") },
+      { id: "recordings", label: t("settings.history.tabs.recordings") },
     ],
     [t],
   );
@@ -299,6 +299,14 @@ export const HistorySettings: React.FC = () => {
       <motion.div variants={staggerItem} style={{ willChange: "transform" }}>
         <div
           role="tabpanel"
+          id="tabpanel-stats"
+          aria-labelledby="tab-stats"
+          className={activeTab !== "stats" ? "hidden" : undefined}
+        >
+          {activeTab === "stats" && <StatsSettings />}
+        </div>
+        <div
+          role="tabpanel"
           id="tabpanel-recordings"
           aria-labelledby="tab-recordings"
           className={activeTab !== "recordings" ? "hidden" : undefined}
@@ -325,14 +333,6 @@ export const HistorySettings: React.FC = () => {
               {recordingsContent}
             </div>
           </div>
-        </div>
-        <div
-          role="tabpanel"
-          id="tabpanel-stats"
-          aria-labelledby="tab-stats"
-          className={activeTab !== "stats" ? "hidden" : undefined}
-        >
-          {activeTab === "stats" && <StatsSettings />}
         </div>
       </motion.div>
     </motion.div>


### PR DESCRIPTION
## Summary
- Move the Stats tab before the Recordings tab in history settings
- Set Stats as the default active tab when opening the history page
- Reorder tab panel DOM to match the new tab order

## Test plan
- [ ] Open Settings → History — verify Stats tab appears first and is selected by default
- [ ] Switch between Stats and Recordings tabs — verify both render correctly