### PR TITLE
refactor: streamline post-processing settings UI

### DIFF
--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -24,6 +24,8 @@ import { ExportImportSettings } from "../advanced/ExportImportSettings";
 import { ConfigFileSettings } from "../advanced/ConfigFileSettings";
 import { AppLanguageSelector } from "../AppLanguageSelector";
 import { AppDataDirectory } from "../AppDataDirectory";
+import { CustomWords } from "../CustomWords";
+import { AppendTrailingSpace } from "../AppendTrailingSpace";
 import { LogDirectory } from "../debug";
 
 export const GeneralSettings: React.FC = () => {
@@ -60,6 +62,8 @@ export const GeneralSettings: React.FC = () => {
         <TypingToolSetting descriptionMode="tooltip" grouped={true} />
         <ClipboardHandlingSetting descriptionMode="tooltip" grouped={true} />
         <AutoSubmit descriptionMode="tooltip" grouped={true} />
+        <CustomWords descriptionMode="tooltip" grouped={true} />
+        <AppendTrailingSpace descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 
       <SettingsGroup title={t("settings.advanced.groups.data")}>

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -1,27 +1,27 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, ArrowsClockwise, X, CaretDown } from "@phosphor-icons/react";
-import { motion, useReducedMotion } from "motion/react";
+import { Check, ArrowsClockwise, X, CaretDown, Plus } from "@phosphor-icons/react";
+import { motion } from "motion/react";
 import { commands } from "@/bindings";
 import type { ShortcutBinding } from "@/bindings";
 
-import { Alert } from "../../ui/Alert";
-import { SettingContainer, SettingsGroup, Textarea } from "@/components/ui";
-import { Button } from "../../ui/Button";
-import { ResetButton } from "../../ui/ResetButton";
-import { Input } from "../../ui/Input";
-import { Badge } from "../../ui/Badge";
-import { SelectableCard } from "../../ui/SelectableCard";
-
-import { ProviderSelect } from "../PostProcessingSettingsApi/ProviderSelect";
-import { BaseUrlField } from "../PostProcessingSettingsApi/BaseUrlField";
-import { ApiKeyField } from "../PostProcessingSettingsApi/ApiKeyField";
-import { ModelSelect } from "../PostProcessingSettingsApi/ModelSelect";
-import { usePostProcessProviderState } from "../PostProcessingSettingsApi/usePostProcessProviderState";
-import { useSettings } from "../../../hooks/useSettings";
-import { usePostProcessStats } from "../../../hooks/usePostProcessStats";
-import { CustomWords } from "../CustomWords";
-import { AppendTrailingSpace } from "../AppendTrailingSpace";
+import {
+  Alert,
+  Badge,
+  Button,
+  Input,
+  SettingContainer,
+  SettingsGroup,
+  Textarea,
+} from "@/components/ui";
+import { ResetButton } from "@/components/ui/ResetButton";
+import { ProviderSelect } from "@/components/settings/PostProcessingSettingsApi/ProviderSelect";
+import { BaseUrlField } from "@/components/settings/PostProcessingSettingsApi/BaseUrlField";
+import { ApiKeyField } from "@/components/settings/PostProcessingSettingsApi/ApiKeyField";
+import { ModelSelect } from "@/components/settings/PostProcessingSettingsApi/ModelSelect";
+import { usePostProcessProviderState } from "@/components/settings/PostProcessingSettingsApi/usePostProcessProviderState";
+import { useSettings } from "@/hooks/useSettings";
+import { usePostProcessStats } from "@/hooks/usePostProcessStats";
 import { spring } from "@/lib/motion";
 import { formatKeyCombination, type OSType } from "@/lib/utils/keyboard";
 import { useOsType } from "@/hooks/useOsType";
@@ -29,6 +29,42 @@ import { useOsType } from "@/hooks/useOsType";
 const BUILTIN_PROMPT_PREFIX = "default_";
 const CREATING_ID = "__creating__";
 const FIELD_WIDTH = "w-[260px]";
+
+/** Reusable clickable row with animated caret for expand/collapse sections. */
+const CollapsibleRow: React.FC<{
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+  trailing?: React.ReactNode;
+}> = ({ expanded, onToggle, children, trailing }) => (
+  <div
+    className="flex items-center justify-between px-3 py-2 cursor-pointer select-none rounded-lg hover:bg-glass-highlight/50 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    onClick={onToggle}
+    role="button"
+    tabIndex={0}
+    onKeyDown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onToggle();
+      }
+    }}
+    aria-expanded={expanded}
+  >
+    <div className="flex items-center gap-2 min-w-0">
+      <motion.div
+        animate={{ rotate: expanded ? 180 : 0 }}
+        transition={spring.gentle}
+        className="shrink-0 text-muted/50"
+      >
+        <CaretDown size={12} weight="bold" />
+      </motion.div>
+      {children}
+    </div>
+    {trailing && (
+      <div className="flex items-center gap-1.5 shrink-0">{trailing}</div>
+    )}
+  </div>
+);
 
 /** Trailing slot matching the ResetButton width to keep fields aligned across rows. */
 const FieldAlignmentSpacer = ({ children }: { children?: React.ReactNode }) => (
@@ -43,148 +79,230 @@ const FieldAlignmentSpacer = ({ children }: { children?: React.ReactNode }) => (
 const PostProcessingSettingsApiComponent: React.FC = () => {
   const { t } = useTranslation();
   const state = usePostProcessProviderState();
+  const stats = usePostProcessStats();
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
+
+  // Default to collapsed when configured, expanded when not
+  useEffect(() => {
+    if (userExpanded !== null) return;
+    if (!state.selectedProvider) return;
+    const configured = state.isAppleProvider || state.apiKey.trim() !== "";
+    setUserExpanded(!configured);
+  }, [userExpanded, state.selectedProvider, state.isAppleProvider, state.apiKey]);
+
+  const expanded = userExpanded ?? true;
+  const toggle = () => setUserExpanded(!expanded);
+
+  const hasProvider = !!state.selectedProvider?.label;
+  const hasModel = !state.isAppleProvider && !!state.model;
+
+  const statsLine = stats
+    ? `${stats.model}${stats.tokens_per_second != null ? ` \u2014 ${stats.tokens_per_second.toFixed(1)} tok/s` : ""}`
+    : null;
 
   return (
     <>
-      <SettingContainer
-        title={t("settings.postProcessing.api.provider.title")}
-        description={t("settings.postProcessing.api.provider.description")}
-        descriptionMode="tooltip"
-        layout="horizontal"
-        grouped={true}
+      {/* Collapsible summary row */}
+      <CollapsibleRow
+        expanded={expanded}
+        onToggle={toggle}
+        trailing={
+          state.isVerified &&
+          !state.isAppleProvider && (
+            <Check
+              className="w-3.5 h-3.5 text-green-400"
+              aria-label={t("settings.postProcessing.api.verified")}
+            />
+          )
+        }
       >
-        <div className="flex items-center gap-2">
-          <ProviderSelect
-            options={state.providerOptions}
-            value={state.selectedProviderId}
-            onChange={state.handleProviderSelect}
-            className={FIELD_WIDTH}
-          />
-          <FieldAlignmentSpacer />
-        </div>
-      </SettingContainer>
-
-      {state.isAppleProvider ? (
-        state.appleIntelligenceUnavailable ? (
-          <Alert variant="destructive" contained>
-            {t("settings.postProcessing.api.appleIntelligence.unavailable")}
-          </Alert>
-        ) : null
-      ) : (
-        <>
-          {state.selectedProvider?.id === "custom" && (
-            <SettingContainer
-              title={t("settings.postProcessing.api.baseUrl.title")}
-              description={t("settings.postProcessing.api.baseUrl.description")}
-              descriptionMode="tooltip"
-              layout="horizontal"
-              grouped={true}
-            >
-              <div className="flex items-center gap-2">
-                <BaseUrlField
-                  value={state.baseUrl}
-                  onBlur={state.handleBaseUrlChange}
-                  placeholder={t(
-                    "settings.postProcessing.api.baseUrl.placeholder",
-                  )}
-                  disabled={state.isBaseUrlUpdating}
-                  className={FIELD_WIDTH}
-                />
-                <FieldAlignmentSpacer />
-              </div>
-            </SettingContainer>
+        <div className="min-w-0">
+          <span className="text-sm truncate block">
+            {hasProvider ? (
+              <>
+                <span className="font-semibold text-text/70">
+                  {state.selectedProvider!.label}
+                </span>
+                {hasModel && (
+                  <span className="text-muted/50">
+                    {" \u00b7 "}
+                    {state.model}
+                  </span>
+                )}
+              </>
+            ) : (
+              <span className="text-muted/70">
+                {t("settings.postProcessing.api.provider.title")}
+              </span>
+            )}
+          </span>
+          {!expanded && stats?.tokens_per_second != null && (
+            <span className="text-xs text-muted/50 truncate block">
+              {stats.tokens_per_second.toFixed(1)} tok/s
+            </span>
           )}
+        </div>
+      </CollapsibleRow>
 
+      {expanded && (
+        <>
           <SettingContainer
-            title={t("settings.postProcessing.api.apiKey.title")}
-            description={t("settings.postProcessing.api.apiKey.description")}
+            title={t("settings.postProcessing.api.provider.title")}
+            description={t("settings.postProcessing.api.provider.description")}
             descriptionMode="tooltip"
             layout="horizontal"
             grouped={true}
           >
             <div className="flex items-center gap-2">
-              <ApiKeyField
-                value={state.apiKey}
-                onBlur={state.handleApiKeyChange}
-                placeholder={t(
-                  "settings.postProcessing.api.apiKey.placeholder",
-                )}
-                disabled={state.isApiKeyUpdating}
+              <ProviderSelect
+                options={state.providerOptions}
+                value={state.selectedProviderId}
+                onChange={state.handleProviderSelect}
                 className={FIELD_WIDTH}
               />
-              <FieldAlignmentSpacer>
-                {state.isVerified && (
-                  <Check
-                    className="w-4 h-4 text-green-400"
-                    aria-label={t("settings.postProcessing.api.verified")}
-                  />
-                )}
-              </FieldAlignmentSpacer>
+              <FieldAlignmentSpacer />
             </div>
           </SettingContainer>
-        </>
-      )}
 
-      {state.fetchError && !state.isAppleProvider && (
-        <Alert
-          variant="destructive"
-          contained
-          className="select-text cursor-text"
-        >
-          <div className="flex items-start justify-between gap-2">
-            <span>{state.fetchError}</span>
-            <button
-              type="button"
-              onClick={state.clearFetchError}
-              className="shrink-0 select-none cursor-pointer opacity-60 hover:opacity-100 transition-opacity"
-              aria-label={t("accessibility.dismiss")}
+          {state.isAppleProvider ? (
+            state.appleIntelligenceUnavailable ? (
+              <Alert variant="destructive" contained>
+                {t(
+                  "settings.postProcessing.api.appleIntelligence.unavailable",
+                )}
+              </Alert>
+            ) : null
+          ) : (
+            <>
+              {state.selectedProvider?.id === "custom" && (
+                <SettingContainer
+                  title={t("settings.postProcessing.api.baseUrl.title")}
+                  description={t(
+                    "settings.postProcessing.api.baseUrl.description",
+                  )}
+                  descriptionMode="tooltip"
+                  layout="horizontal"
+                  grouped={true}
+                >
+                  <div className="flex items-center gap-2">
+                    <BaseUrlField
+                      value={state.baseUrl}
+                      onBlur={state.handleBaseUrlChange}
+                      placeholder={t(
+                        "settings.postProcessing.api.baseUrl.placeholder",
+                      )}
+                      disabled={state.isBaseUrlUpdating}
+                      className={FIELD_WIDTH}
+                    />
+                    <FieldAlignmentSpacer />
+                  </div>
+                </SettingContainer>
+              )}
+
+              <SettingContainer
+                title={t("settings.postProcessing.api.apiKey.title")}
+                description={t(
+                  "settings.postProcessing.api.apiKey.description",
+                )}
+                descriptionMode="tooltip"
+                layout="horizontal"
+                grouped={true}
+              >
+                <div className="flex items-center gap-2">
+                  <ApiKeyField
+                    value={state.apiKey}
+                    onBlur={state.handleApiKeyChange}
+                    placeholder={t(
+                      "settings.postProcessing.api.apiKey.placeholder",
+                    )}
+                    disabled={state.isApiKeyUpdating}
+                    className={FIELD_WIDTH}
+                  />
+                  <FieldAlignmentSpacer>
+                    {state.isVerified && (
+                      <Check
+                        className="w-4 h-4 text-green-400"
+                        aria-label={t("settings.postProcessing.api.verified")}
+                      />
+                    )}
+                  </FieldAlignmentSpacer>
+                </div>
+              </SettingContainer>
+            </>
+          )}
+
+          {state.fetchError && !state.isAppleProvider && (
+            <Alert
+              variant="destructive"
+              contained
+              className="select-text cursor-text"
             >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-        </Alert>
-      )}
+              <div className="flex items-start justify-between gap-2">
+                <span>{state.fetchError}</span>
+                <button
+                  type="button"
+                  onClick={state.clearFetchError}
+                  className="shrink-0 select-none cursor-pointer opacity-60 hover:opacity-100 transition-opacity"
+                  aria-label={t("accessibility.dismiss")}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            </Alert>
+          )}
 
-      {!state.isAppleProvider && (
-        <SettingContainer
-          title={t("settings.postProcessing.api.model.title")}
-          description={
-            state.isCustomProvider
-              ? t("settings.postProcessing.api.model.descriptionCustom")
-              : t("settings.postProcessing.api.model.descriptionDefault")
-          }
-          descriptionMode="tooltip"
-          layout="horizontal"
-          grouped={true}
-        >
-          <div className="flex items-center gap-2">
-            <ModelSelect
-              value={state.model}
-              options={state.modelOptions}
-              disabled={state.isModelUpdating}
-              isLoading={state.isFetchingModels}
-              placeholder={
-                state.modelOptions.length > 0
-                  ? t(
-                      "settings.postProcessing.api.model.placeholderWithOptions",
-                    )
-                  : t("settings.postProcessing.api.model.placeholderNoOptions")
+          {!state.isAppleProvider && (
+            <SettingContainer
+              title={t("settings.postProcessing.api.model.title")}
+              description={
+                state.isCustomProvider
+                  ? t("settings.postProcessing.api.model.descriptionCustom")
+                  : t("settings.postProcessing.api.model.descriptionDefault")
               }
-              onSelect={state.handleModelSelect}
-              onCreateValue={state.handleModelSelect}
-              className={FIELD_WIDTH}
-            />
-            <ResetButton
-              onClick={state.handleRefreshModels}
-              disabled={state.isFetchingModels}
-              ariaLabel={t("settings.postProcessing.api.model.refreshModels")}
+              descriptionMode="tooltip"
+              layout="horizontal"
+              grouped={true}
             >
-              <ArrowsClockwise
-                className={`h-4 w-4 ${state.isFetchingModels ? "animate-spin" : ""}`}
-              />
-            </ResetButton>
-          </div>
-        </SettingContainer>
+              <div className="flex items-center gap-2">
+                <ModelSelect
+                  value={state.model}
+                  options={state.modelOptions}
+                  disabled={state.isModelUpdating}
+                  isLoading={state.isFetchingModels}
+                  placeholder={
+                    state.modelOptions.length > 0
+                      ? t(
+                          "settings.postProcessing.api.model.placeholderWithOptions",
+                        )
+                      : t(
+                          "settings.postProcessing.api.model.placeholderNoOptions",
+                        )
+                  }
+                  onSelect={state.handleModelSelect}
+                  onCreateValue={state.handleModelSelect}
+                  className={FIELD_WIDTH}
+                />
+                <ResetButton
+                  onClick={state.handleRefreshModels}
+                  disabled={state.isFetchingModels}
+                  ariaLabel={t(
+                    "settings.postProcessing.api.model.refreshModels",
+                  )}
+                >
+                  <ArrowsClockwise
+                    className={`h-4 w-4 ${state.isFetchingModels ? "animate-spin" : ""}`}
+                  />
+                </ResetButton>
+              </div>
+            </SettingContainer>
+          )}
+
+          {statsLine && (
+            <div className="px-3 py-2">
+              <p className="text-xs text-muted/70">{statsLine}</p>
+            </div>
+          )}
+        </>
       )}
     </>
   );
@@ -226,10 +344,20 @@ const PromptFields: React.FC<PromptFieldsProps> = ({
   autoFocus,
 }) => {
   const { t } = useTranslation();
+  const id = useId();
+  const nameId = `${id}-name`;
+  const textId = `${id}-text`;
   return (
-    <>
-      <div>
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <label
+          htmlFor={nameId}
+          className="text-[11px] font-medium uppercase tracking-wider text-muted/50 block"
+        >
+          {t("settings.postProcessing.prompts.promptLabel")}
+        </label>
         <Input
+          id={nameId}
           type="text"
           value={name}
           onChange={(e) => onNameChange(e.target.value)}
@@ -237,33 +365,43 @@ const PromptFields: React.FC<PromptFieldsProps> = ({
             "settings.postProcessing.prompts.promptLabelPlaceholder",
           )}
           disabled={disabled}
-          className="rounded-b-none border-b-0 text-sm font-semibold"
+          className="text-sm font-semibold"
           autoFocus={autoFocus}
         />
+      </div>
+      <div className="space-y-1">
+        <label
+          htmlFor={textId}
+          className="text-[11px] font-medium uppercase tracking-wider text-muted/50 block"
+        >
+          {t("settings.postProcessing.prompts.promptInstructions")}
+        </label>
         <Textarea
+          id={textId}
           value={text}
           onChange={(e) => onTextChange(e.target.value)}
           placeholder={t(
             "settings.postProcessing.prompts.promptInstructionsPlaceholder",
           )}
           disabled={disabled}
-          className="min-h-[200px] rounded-t-none"
+          className="min-h-[180px]"
         />
       </div>
-      <p className="text-xs text-muted/70">
+      <p className="text-[11px] text-muted/40 leading-relaxed">
         {disabled
           ? t("settings.postProcessing.prompts.builtInReadOnly")
           : t("settings.postProcessing.prompts.promptTip")}
       </p>
-    </>
+    </div>
   );
 };
 
-const PostProcessingSettingsPromptsComponent: React.FC = () => {
+const PostProcessingSettingsPromptsComponent = React.forwardRef<{
+  startCreate: () => void;
+}>(function PostProcessingSettingsPromptsComponent(_, ref) {
   const { t } = useTranslation();
   const { getSetting, refreshSettings } = useSettings();
   const osType = useOsType();
-  const reducedMotion = useReducedMotion();
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const isCreating = expandedId === CREATING_ID;
   const [draftName, setDraftName] = useState("");
@@ -303,6 +441,10 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
     setFormError(null);
     setExpandedId(null);
   };
+
+  React.useImperativeHandle(ref, () => ({
+    startCreate: handleStartCreate,
+  }));
 
   const handleCreatePrompt = async () => {
     if (!draftName.trim() || !draftText.trim()) return;
@@ -361,63 +503,26 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
   };
 
   return (
-    <div className="px-3 py-1.5">
-      <div className="space-y-2">
-        {/* Prompt cards */}
-        {prompts.map((prompt) => {
-          const isExpanded = expandedId === prompt.id;
-          const isBuiltIn = prompt.id.startsWith(BUILTIN_PROMPT_PREFIX);
-          const shortcuts = shortcutMap[prompt.id] || [];
-          const isDirty =
-            isExpanded &&
-            expandedPrompt &&
-            (draftName.trim() !== expandedPrompt.name ||
-              draftText.trim() !== expandedPrompt.prompt.trim());
+    <div className="divide-y divide-glass-border">
+      {/* Prompt rows */}
+      {prompts.map((prompt) => {
+        const isExpanded = expandedId === prompt.id;
+        const isBuiltIn = prompt.id.startsWith(BUILTIN_PROMPT_PREFIX);
+        const shortcuts = shortcutMap[prompt.id] || [];
+        const isDirty =
+          isExpanded &&
+          expandedPrompt &&
+          (draftName.trim() !== expandedPrompt.name ||
+            draftText.trim() !== expandedPrompt.prompt.trim());
 
-          return (
-            <SelectableCard
-              key={prompt.id}
-              active={isExpanded}
-              clickable={!isExpanded}
-              compact
-              onClick={() => handleToggle(prompt.id)}
-            >
-              {/* Header row — always visible */}
-              <div
-                className={`flex items-center gap-2 ${isExpanded ? "cursor-pointer" : ""}`}
-                role={isExpanded ? "button" : undefined}
-                tabIndex={isExpanded ? 0 : undefined}
-                aria-expanded={isExpanded}
-                onClick={() => {
-                  if (!isExpanded) return;
-                  handleToggle(prompt.id);
-                }}
-                onKeyDown={(e) => {
-                  if (!isExpanded) return;
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleToggle(prompt.id);
-                  }
-                }}
-              >
-                <motion.div
-                  animate={{ rotate: isExpanded ? 180 : 0 }}
-                  transition={spring.gentle}
-                  className="shrink-0 text-muted/50"
-                >
-                  <CaretDown size={12} weight="bold" />
-                </motion.div>
-                <div className="flex-1 min-w-0">
-                  <span className="text-sm font-semibold truncate block">
-                    {prompt.name}
-                  </span>
-                  {!isExpanded && (
-                    <span className="text-xs text-muted/50 truncate block">
-                      {prompt.prompt.split("\n")[0]}
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-1.5 shrink-0">
+        return (
+          <div key={prompt.id}>
+            {/* Collapsible header row */}
+            <CollapsibleRow
+              expanded={isExpanded}
+              onToggle={() => handleToggle(prompt.id)}
+              trailing={
+                <>
                   {shortcuts.map((s) => (
                     <Badge
                       key={s.id}
@@ -435,138 +540,121 @@ const PostProcessingSettingsPromptsComponent: React.FC = () => {
                       {t("settings.postProcessing.prompts.builtIn")}
                     </Badge>
                   )}
-                </div>
-              </div>
-
-              {/* Expanded content */}
-              <div
-                className="grid"
-                aria-hidden={!isExpanded}
-                style={{
-                  gridTemplateRows: isExpanded ? "1fr" : "0fr",
-                  opacity: isExpanded ? 1 : 0,
-                  transition: reducedMotion
-                    ? undefined
-                    : "grid-template-rows 200ms ease-out, opacity 200ms ease-out",
-                }}
-              >
-                <div className="overflow-hidden min-h-0">
-                  <div className="space-y-3 pt-2">
-                    <PromptFields
-                      name={draftName}
-                      text={draftText}
-                      onNameChange={setDraftName}
-                      onTextChange={setDraftText}
-                      disabled={isBuiltIn}
-                    />
-
-                    {!isBuiltIn && (
-                      <div className="space-y-2">
-                        <div className="flex gap-2 pt-1">
-                          <Button
-                            onClick={handleUpdatePrompt}
-                            variant="default"
-                            size="default"
-                            disabled={
-                              isSubmitting ||
-                              !draftName.trim() ||
-                              !draftText.trim() ||
-                              !isDirty
-                            }
-                          >
-                            {t("settings.postProcessing.prompts.updatePrompt")}
-                          </Button>
-                          <Button
-                            onClick={() => handleDeletePrompt(prompt.id)}
-                            variant="danger-ghost"
-                            size="default"
-                            disabled={isSubmitting || prompts.length <= 1}
-                          >
-                            {t("settings.postProcessing.prompts.deletePrompt")}
-                          </Button>
-                        </div>
-                        {formError && isExpanded && (
-                          <Alert variant="destructive" contained>
-                            {formError}
-                          </Alert>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </SelectableCard>
-          );
-        })}
-
-        {/* Create new prompt form */}
-        {isCreating && (
-          <SelectableCard active compact>
-            <div className="space-y-3">
-              <PromptFields
-                name={draftName}
-                text={draftText}
-                onNameChange={setDraftName}
-                onTextChange={setDraftText}
-                autoFocus
-              />
-              <div className="space-y-2">
-                <div className="flex gap-2 pt-1">
-                  <Button
-                    onClick={handleCreatePrompt}
-                    variant="default"
-                    size="default"
-                    disabled={
-                      isSubmitting || !draftName.trim() || !draftText.trim()
-                    }
-                  >
-                    {t("settings.postProcessing.prompts.createPrompt")}
-                  </Button>
-                  <Button
-                    onClick={handleCancelCreate}
-                    variant="secondary"
-                    size="default"
-                  >
-                    {t("settings.postProcessing.prompts.cancel")}
-                  </Button>
-                </div>
-                {formError && (
-                  <Alert variant="destructive" contained>
-                    {formError}
-                  </Alert>
+                </>
+              }
+            >
+              <div className="min-w-0">
+                <span className="text-sm font-semibold text-text/70 truncate block">
+                  {prompt.name}
+                </span>
+                {!isExpanded && (
+                  <span className="text-xs text-muted/50 truncate block">
+                    {prompt.prompt.split("\n")[0]}
+                  </span>
                 )}
               </div>
-            </div>
-          </SelectableCard>
-        )}
+            </CollapsibleRow>
 
-        {/* Empty state */}
-        {prompts.length === 0 && !isCreating && (
-          <div className="p-3 bg-muted/5 rounded border border-muted/20">
-            <p className="text-sm text-muted">
-              {t("settings.postProcessing.prompts.createFirst")}
-            </p>
-            <p className="text-xs text-muted/60 mt-1">
-              {t("settings.postProcessing.prompts.createFirstHint")}
-            </p>
+            {/* Expanded content */}
+            {isExpanded && (
+              <div className="px-3 pb-3 pt-1 space-y-3">
+                <PromptFields
+                  name={draftName}
+                  text={draftText}
+                  onNameChange={setDraftName}
+                  onTextChange={setDraftText}
+                  disabled={isBuiltIn}
+                />
+
+                {!isBuiltIn && (
+                  <>
+                    <div className="flex items-center justify-end gap-2 pt-2 border-t border-glass-border/30">
+                      <Button
+                        onClick={() => handleDeletePrompt(prompt.id)}
+                        variant="danger-ghost"
+                        size="default"
+                        disabled={isSubmitting || prompts.length <= 1}
+                      >
+                        {t("settings.postProcessing.prompts.deletePrompt")}
+                      </Button>
+                      <Button
+                        onClick={handleUpdatePrompt}
+                        variant="default"
+                        size="default"
+                        disabled={
+                          isSubmitting ||
+                          !draftName.trim() ||
+                          !draftText.trim() ||
+                          !isDirty
+                        }
+                      >
+                        {t("settings.postProcessing.prompts.updatePrompt")}
+                      </Button>
+                    </div>
+                    {formError && (
+                      <Alert variant="destructive" contained>
+                        {formError}
+                      </Alert>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
           </div>
-        )}
+        );
+      })}
 
-        {/* New Prompt button */}
-        {!isCreating && (
-          <Button
-            onClick={handleStartCreate}
-            variant="secondary"
-            size="default"
-            className="w-full"
-          >
-            {t("settings.postProcessing.prompts.createNew")}
-          </Button>
-        )}
-      </div>
+      {/* Create new prompt form */}
+      {isCreating && (
+        <div className="px-3 py-3 space-y-3">
+          <PromptFields
+            name={draftName}
+            text={draftText}
+            onNameChange={setDraftName}
+            onTextChange={setDraftText}
+            autoFocus
+          />
+          <div className="flex items-center gap-2 pt-2 border-t border-glass-border/30">
+            <Button
+              onClick={handleCreatePrompt}
+              variant="default"
+              size="default"
+              disabled={
+                isSubmitting || !draftName.trim() || !draftText.trim()
+              }
+            >
+              {t("settings.postProcessing.prompts.createPrompt")}
+            </Button>
+            <Button
+              onClick={handleCancelCreate}
+              variant="secondary"
+              size="default"
+            >
+              {t("settings.postProcessing.prompts.cancel")}
+            </Button>
+          </div>
+          {formError && (
+            <Alert variant="destructive" contained>
+              {formError}
+            </Alert>
+          )}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {prompts.length === 0 && !isCreating && (
+        <div className="px-3 py-3">
+          <p className="text-sm text-muted">
+            {t("settings.postProcessing.prompts.createFirst")}
+          </p>
+          <p className="text-xs text-muted/60 mt-1">
+            {t("settings.postProcessing.prompts.createFirstHint")}
+          </p>
+        </div>
+      )}
     </div>
   );
-};
+});
 
 export const PostProcessingSettingsApi = React.memo(
   PostProcessingSettingsApiComponent,
@@ -580,31 +668,29 @@ PostProcessingSettingsPrompts.displayName = "PostProcessingSettingsPrompts";
 
 export const PostProcessingSettings: React.FC = () => {
   const { t } = useTranslation();
-  const stats = usePostProcessStats();
-
-  const statsLine = stats
-    ? `${stats.model}${stats.tokens_per_second != null ? ` — ${stats.tokens_per_second.toFixed(1)} tok/s` : ""}`
-    : null;
+  const promptsRef = useRef<{ startCreate: () => void }>(null);
 
   return (
     <div className="max-w-3xl w-full mx-auto space-y-8">
       <h1 className="sr-only">{t("sidebar.postProcessing")}</h1>
       <SettingsGroup title={t("settings.postProcessing.api.title")}>
         <PostProcessingSettingsApi />
-        {statsLine && (
-          <div className="px-3 py-2">
-            <p className="text-xs text-muted/70">{statsLine}</p>
-          </div>
-        )}
       </SettingsGroup>
 
-      <SettingsGroup title={t("settings.postProcessing.prompts.title")}>
-        <PostProcessingSettingsPrompts />
-      </SettingsGroup>
-
-      <SettingsGroup title={t("settings.advanced.groups.transcription")}>
-        <CustomWords descriptionMode="tooltip" grouped />
-        <AppendTrailingSpace descriptionMode="tooltip" grouped={true} />
+      <SettingsGroup
+        title={t("settings.postProcessing.prompts.title")}
+        action={
+          <button
+            type="button"
+            className="p-1 rounded-lg text-muted/50 hover:text-text/70 hover:bg-glass-highlight/50 transition-colors"
+            onClick={() => promptsRef.current?.startCreate()}
+            aria-label={t("settings.postProcessing.prompts.createNew")}
+          >
+            <Plus size={14} weight="bold" />
+          </button>
+        }
+      >
+        <PostProcessingSettingsPrompts ref={promptsRef} />
       </SettingsGroup>
     </div>
   );

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -138,7 +138,7 @@ const SearchableDropdown: React.FC<DropdownProps> = ({
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         className={cn(
-          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded",
+          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded-md",
           "min-w-[160px] text-start flex items-center justify-between",
           "transition-all duration-150",
           disabled
@@ -279,7 +279,7 @@ const SimpleDropdown: React.FC<DropdownProps> = ({
     >
       <SelectPrimitive.Trigger
         className={cn(
-          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded",
+          "px-2 py-1 text-sm font-semibold bg-glass-bg border border-glass-border rounded-md",
           "min-w-[160px] text-start flex items-center justify-between",
           "transition-all duration-150",
           disabled

--- a/src/components/ui/SettingsGroup.tsx
+++ b/src/components/ui/SettingsGroup.tsx
@@ -5,24 +5,29 @@ import { staggerContainer, staggerItem } from "@/lib/motion";
 interface SettingsGroupProps {
   title?: string;
   description?: string;
+  action?: React.ReactNode;
   children: React.ReactNode;
 }
 
 export const SettingsGroup: React.FC<SettingsGroupProps> = ({
   title,
   description,
+  action,
   children,
 }) => {
   return (
     <div className="space-y-2">
       {title && (
-        <div className="px-3">
-          <h2 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
-            {title}
-          </h2>
-          {description && (
-            <p className="text-xs text-muted mt-0.5">{description}</p>
-          )}
+        <div className="px-3 flex items-center justify-between">
+          <div>
+            <h2 className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+              {title}
+            </h2>
+            {description && (
+              <p className="text-xs text-muted mt-0.5">{description}</p>
+            )}
+          </div>
+          {action}
         </div>
       )}
       <motion.div


### PR DESCRIPTION
## Summary
- Make the API configuration section collapsible with a summary row showing provider, model, and tok/s stats (auto-collapses when configured)
- Replace SelectableCard prompt entries with simpler collapsible rows and a shared CollapsibleRow component
- Move CustomWords and AppendTrailingSpace settings into General Settings
- Add `action` prop to SettingsGroup for header-level controls (used for the new + button to create prompts)
- Fix dropdown border radius consistency (rounded → rounded-md)

## Test plan
- [ ] Verify post-processing settings page renders correctly with collapsible API section
- [ ] Confirm API section auto-collapses when provider is configured, expands when not
- [ ] Test prompt creation via the + button in the section header
- [ ] Verify CustomWords and AppendTrailingSpace appear in General Settings
- [ ] Check dropdown border radius consistency across the app