### PR TITLE
fix: use i18n for tokens-per-second string

### DIFF
--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -97,7 +97,7 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
   const hasModel = !state.isAppleProvider && !!state.model;
 
   const statsLine = stats
-    ? `${stats.model}${stats.tokens_per_second != null ? ` \u2014 ${stats.tokens_per_second.toFixed(1)} tok/s` : ""}`
+    ? `${stats.model}${stats.tokens_per_second != null ? ` \u2014 ${t("settings.postProcessing.api.tokensPerSecond", { value: stats.tokens_per_second.toFixed(1) })}` : ""}`
     : null;
 
   return (
@@ -138,7 +138,7 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
           </span>
           {!expanded && stats?.tokens_per_second != null && (
             <span className="text-xs text-muted/50 truncate block">
-              {stats.tokens_per_second.toFixed(1)} tok/s
+              {t("settings.postProcessing.api.tokensPerSecond", { value: stats.tokens_per_second.toFixed(1) })}
             </span>
           )}
         </div>

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -389,6 +389,7 @@
           "placeholderNoOptions": "اكتب اسم النموذج",
           "refreshModels": "تحديث النماذج"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "تم التحقق"
       },
       "prompts": {

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Zadejte název modelu",
           "refreshModels": "Obnovit modely"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Ověřeno"
       },
       "prompts": {

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Modellnamen eingeben",
           "refreshModels": "Modelle aktualisieren"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Verifiziert"
       },
       "prompts": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -467,7 +467,8 @@
           "placeholderWithOptions": "Search or select a model",
           "placeholderNoOptions": "Type a model name",
           "refreshModels": "Refresh models"
-        }
+        },
+        "tokensPerSecond": "{{value}} tok/s"
       },
       "prompts": {
         "title": "Prompt",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Escribe un nombre de modelo",
           "refreshModels": "Actualizar modelos"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Verificado"
       },
       "prompts": {

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Tapez un nom de modèle",
           "refreshModels": "Actualiser les modèles"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Vérifié"
       },
       "prompts": {

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Digita il nome di un modello",
           "refreshModels": "Aggiorna modelli"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Verificato"
       },
       "prompts": {

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "モデル名を入力",
           "refreshModels": "モデルを更新"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "確認済み"
       },
       "prompts": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "모델 이름 입력",
           "refreshModels": "모델 새로고침"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "인증됨"
       },
       "prompts": {

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Wpisz nazwę modelu",
           "refreshModels": "Odśwież modele"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Zweryfikowano"
       },
       "prompts": {

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Digite o nome de um modelo",
           "refreshModels": "Atualizar modelos"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Verificado"
       },
       "prompts": {

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Введите название модели",
           "refreshModels": "Обновить модели"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Подтверждено"
       },
       "prompts": {

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Model adı yazın",
           "refreshModels": "Modelleri Yenile"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Doğrulandı"
       },
       "prompts": {

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Введіть назву моделі",
           "refreshModels": "Оновити моделі"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Перевірено"
       },
       "prompts": {

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "Nhập tên mô hình",
           "refreshModels": "Làm mới mô hình"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "Đã xác minh"
       },
       "prompts": {

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "輸入模型名稱",
           "refreshModels": "重新整理模型"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "已驗證"
       },
       "prompts": {

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -467,6 +467,7 @@
           "placeholderNoOptions": "输入模型名称",
           "refreshModels": "刷新模型"
         },
+        "tokensPerSecond": "{{value}} tok/s",
         "verified": "已验证"
       },
       "prompts": {


### PR DESCRIPTION
## Summary
- Replace hardcoded `tok/s` literal with `t("settings.postProcessing.api.tokensPerSecond")` to fix `i18next/no-literal-string` ESLint error
- Add `tokensPerSecond` key to all 17 locale files

## Test plan
- [x] `bun run lint` passes
- [x] `bun run check:translations` passes — all 16 languages have complete translations