### PR TITLE
feat: add pricing configuration and cost estimates for post-processing

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -309,6 +309,8 @@ pub fn run(cli_args: CliArgs) {
         post_process::commands::add_post_process_prompt,
         post_process::commands::update_post_process_prompt,
         post_process::commands::delete_post_process_prompt,
+        post_process::commands::set_post_process_pricing,
+        post_process::commands::lookup_model_pricing,
         post_process::commands::set_post_process_selected_prompt,
         shortcut::update_custom_words,
         shortcut::suspend_binding,

--- a/src-tauri/src/post_process/commands.rs
+++ b/src-tauri/src/post_process/commands.rs
@@ -1,3 +1,4 @@
+use crate::post_process::pricing::ModelPricing;
 use crate::post_process::prompts::{is_builtin_prompt, LLMPrompt};
 use crate::settings::{self, APPLE_INTELLIGENCE_DEFAULT_MODEL_ID, APPLE_INTELLIGENCE_PROVIDER_ID};
 use tauri::AppHandle;
@@ -231,6 +232,35 @@ pub fn delete_post_process_prompt(app: AppHandle, id: String) -> Result<(), Stri
 
     settings::write_settings(&app, settings);
     Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn set_post_process_pricing(
+    app: AppHandle,
+    provider_id: String,
+    input_price: f64,
+    output_price: f64,
+) -> Result<(), String> {
+    let mut settings = settings::get_settings(&app);
+    validate_provider_exists(&settings, &provider_id)?;
+    settings
+        .post_process_input_prices
+        .insert(provider_id.clone(), input_price);
+    settings
+        .post_process_output_prices
+        .insert(provider_id, output_price);
+    settings::write_settings(&app, settings);
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn lookup_model_pricing(
+    provider_id: String,
+    model_id: String,
+) -> Result<Option<ModelPricing>, String> {
+    Ok(crate::post_process::pricing::lookup(&provider_id, &model_id).await)
 }
 
 #[tauri::command]

--- a/src-tauri/src/post_process/mod.rs
+++ b/src-tauri/src/post_process/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod commands;
+pub mod pricing;
 pub mod process;
 pub mod prompts;
 pub mod providers;

--- a/src-tauri/src/post_process/pricing.rs
+++ b/src-tauri/src/post_process/pricing.rs
@@ -1,0 +1,139 @@
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Pricing info returned to the frontend ($/M tokens).
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct ModelPricing {
+    pub input: f64,
+    pub output: f64,
+}
+
+/// Parsed cost block from models.dev JSON.
+#[derive(Deserialize)]
+struct ApiCost {
+    input: Option<f64>,
+    output: Option<f64>,
+}
+
+/// A single model entry from models.dev.
+#[derive(Deserialize)]
+struct ApiModel {
+    id: Option<String>,
+    cost: Option<ApiCost>,
+}
+
+/// A provider entry from models.dev (contains a `models` map).
+#[derive(Deserialize)]
+struct ApiProvider {
+    models: Option<HashMap<String, ApiModel>>,
+}
+
+struct PricingCache {
+    data: HashMap<String, ModelPricing>,
+    fetched_at: Instant,
+}
+
+static CACHE: Mutex<Option<PricingCache>> = Mutex::new(None);
+const CACHE_TTL: Duration = Duration::from_secs(3600); // 1 hour
+
+/// Fetch and parse the models.dev API into a flat model_id → pricing map.
+async fn fetch_pricing_data() -> Result<HashMap<String, ModelPricing>, String> {
+    debug!("Fetching pricing data from models.dev");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let response = client
+        .get("https://models.dev/api.json")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch models.dev: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "models.dev returned status {}",
+            response.status()
+        ));
+    }
+
+    let providers: HashMap<String, ApiProvider> = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse models.dev JSON: {e}"))?;
+
+    let mut pricing = HashMap::new();
+    for provider in providers.values() {
+        if let Some(models) = &provider.models {
+            for model in models.values() {
+                if let (Some(id), Some(cost)) = (&model.id, &model.cost) {
+                    if let (Some(input), Some(output)) = (cost.input, cost.output) {
+                        pricing.entry(id.clone()).or_insert(ModelPricing {
+                            input,
+                            output,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    debug!("Loaded pricing for {} models from models.dev", pricing.len());
+    Ok(pricing)
+}
+
+/// Resolve a (provider_id, model_id) pair to the models.dev lookup key.
+fn resolve_models_dev_id(provider_id: &str, model_id: &str) -> Option<String> {
+    if model_id.is_empty() {
+        return None;
+    }
+    match provider_id {
+        "custom" | "apple_intelligence" => None,
+        "gemini" => Some(format!("google/{model_id}")),
+        // OpenRouter models already use "vendor/model" format
+        "openrouter" => Some(model_id.to_string()),
+        // openai, anthropic, groq, cerebras, zai: try "provider/model"
+        other => Some(format!("{other}/{model_id}")),
+    }
+}
+
+/// Look up pricing for a given provider + model combination.
+/// Returns None if the model isn't found or if the fetch fails.
+pub async fn lookup(provider_id: &str, model_id: &str) -> Option<ModelPricing> {
+    let lookup_key = resolve_models_dev_id(provider_id, model_id)?;
+
+    // Check cache
+    {
+        let cache = CACHE.lock().ok()?;
+        if let Some(ref c) = *cache {
+            if c.fetched_at.elapsed() < CACHE_TTL {
+                return c.data.get(&lookup_key).cloned();
+            }
+        }
+    }
+
+    // Fetch fresh data
+    match fetch_pricing_data().await {
+        Ok(data) => {
+            let result = data.get(&lookup_key).cloned();
+            if let Ok(mut cache) = CACHE.lock() {
+                *cache = Some(PricingCache {
+                    data,
+                    fetched_at: Instant::now(),
+                });
+            }
+            result
+        }
+        Err(e) => {
+            warn!("Failed to fetch pricing data: {e}");
+            // Return stale cache if available
+            let cache = CACHE.lock().ok()?;
+            cache.as_ref()?.data.get(&lookup_key).cloned()
+        }
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -388,6 +388,10 @@ pub struct AppSettings {
     pub stt_verified_providers: HashSet<String>,
     #[serde(default)]
     pub post_process_verified_providers: HashSet<String>,
+    #[serde(default)]
+    pub post_process_input_prices: HashMap<String, f64>,
+    #[serde(default)]
+    pub post_process_output_prices: HashMap<String, f64>,
     #[serde(default = "default_stt_cloud_options")]
     pub stt_cloud_options: HashMap<String, String>,
     #[serde(default)]
@@ -768,6 +772,8 @@ pub fn get_default_settings() -> AppSettings {
         app_theme: AppTheme::default(),
         stt_verified_providers: HashSet::new(),
         post_process_verified_providers: HashSet::new(),
+        post_process_input_prices: HashMap::new(),
+        post_process_output_prices: HashMap::new(),
         stt_cloud_options: default_stt_cloud_options(),
         stt_realtime_enabled: HashMap::new(),
         stats_date_range: StatsDateRange::default(),

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -240,6 +240,22 @@ async deletePostProcessPrompt(id: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async setPostProcessPricing(providerId: string, inputPrice: number, outputPrice: number) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_post_process_pricing", { providerId, inputPrice, outputPrice }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async lookupModelPricing(providerId: string, modelId: string) : Promise<Result<ModelPricing | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("lookup_model_pricing", { providerId, modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async setPostProcessSelectedPrompt(id: string | null) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("set_post_process_selected_prompt", { id }) };
@@ -873,7 +889,7 @@ async isLaptop() : Promise<Result<boolean, string>> {
 
 /** user-defined types **/
 
-export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; microphone_priority?: string[]; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; stt_provider_id?: string; stt_providers?: SttProvider[]; stt_api_keys?: Partial<{ [key in string]: string }>; stt_cloud_models?: Partial<{ [key in string]: string }>; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; app_theme?: AppTheme; stt_verified_providers?: string[]; post_process_verified_providers?: string[]; stt_cloud_options?: Partial<{ [key in string]: string }>; stt_realtime_enabled?: Partial<{ [key in string]: boolean }>; stats_date_range?: StatsDateRange }
+export type AppSettings = { bindings: Partial<{ [key in string]: ShortcutBinding }>; push_to_talk: boolean; audio_feedback_volume?: number; sound_theme?: SoundTheme; start_hidden?: boolean; autostart_enabled?: boolean; update_checks_enabled?: boolean; selected_model?: string; always_on_microphone?: boolean; selected_microphone?: string | null; microphone_priority?: string[]; clamshell_microphone?: string | null; selected_output_device?: string | null; translate_to_english?: boolean; selected_language?: string; overlay_position?: OverlayPosition; debug_mode?: boolean; log_level?: LogLevel; custom_words?: string[]; model_unload_timeout?: ModelUnloadTimeout; word_correction_threshold?: number; history_limit?: number; recording_retention_period?: RecordingRetentionPeriod; paste_method?: PasteMethod; clipboard_handling?: ClipboardHandling; auto_submit?: boolean; auto_submit_key?: AutoSubmitKey; stt_provider_id?: string; stt_providers?: SttProvider[]; stt_api_keys?: Partial<{ [key in string]: string }>; stt_cloud_models?: Partial<{ [key in string]: string }>; post_process_enabled?: boolean; post_process_provider_id?: string; post_process_providers?: PostProcessProvider[]; post_process_api_keys?: Partial<{ [key in string]: string }>; post_process_models?: Partial<{ [key in string]: string }>; post_process_prompts?: LLMPrompt[]; post_process_selected_prompt_id?: string | null; mute_while_recording?: boolean; append_trailing_space?: boolean; app_language?: string; keyboard_implementation?: KeyboardImplementation; show_tray_icon?: boolean; paste_delay_ms?: number; typing_tool?: TypingTool; external_script_path: string | null; app_theme?: AppTheme; stt_verified_providers?: string[]; post_process_verified_providers?: string[]; post_process_input_prices?: Partial<{ [key in string]: number }>; post_process_output_prices?: Partial<{ [key in string]: number }>; stt_cloud_options?: Partial<{ [key in string]: string }>; stt_realtime_enabled?: Partial<{ [key in string]: boolean }>; stats_date_range?: StatsDateRange }
 export type AppTheme = "dark" | "light" | "system"
 export type AudioDevice = { index: string; name: string; is_default: boolean }
 export type AutoSubmitKey = "enter" | "ctrl_enter" | "cmd_enter"
@@ -900,6 +916,10 @@ export type LLMPrompt = { id: string; name: string; prompt: string }
 export type LogLevel = "trace" | "debug" | "info" | "warn" | "error"
 export type ModelInfo = { id: string; name: string; description: string; filename: string; url: string | null; size_mb: number; is_downloaded: boolean; is_downloading: boolean; partial_size: number; is_directory: boolean; engine_type: EngineType; accuracy_score: number; speed_score: number; supports_translation: boolean; is_recommended: boolean; supported_languages: string[]; is_custom: boolean }
 export type ModelLoadStatus = { is_loaded: boolean; current_model: string | null }
+/**
+ * Pricing info returned to the frontend ($/M tokens).
+ */
+export type ModelPricing = { input: number; output: number }
 export type ModelUnloadTimeout = "never" | "immediately" | "min_2" | "min_5" | "min_10" | "min_15" | "hour_1" | "sec_5"
 export type OverlayPosition = "none" | "top" | "bottom"
 export type PasteMethod = "ctrl_v" | "direct" | "none" | "shift_insert" | "ctrl_shift_v" | "external_script"

--- a/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
+++ b/src/components/settings/PostProcessingSettingsApi/usePostProcessProviderState.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
 import { useSettings } from "../../../hooks/useSettings";
-import { commands, type PostProcessProvider } from "@/bindings";
+import { commands, type ModelPricing, type PostProcessProvider } from "@/bindings";
 import type { DropdownOption } from "../../ui/Dropdown";
+import { useModelPricing } from "@/hooks/useModelPricing";
 
 type PostProcessProviderState = {
   providerOptions: DropdownOption[];
@@ -26,6 +27,12 @@ type PostProcessProviderState = {
   handleProviderSelect: (providerId: string) => void;
   handleModelSelect: (value: string) => void;
   handleRefreshModels: () => void;
+  inputPrice: number;
+  outputPrice: number;
+  handlePricingChange: (inputPrice: number, outputPrice: number) => void;
+  isPricingUpdating: boolean;
+  autoPricing: ModelPricing | null;
+  isAutoLoading: boolean;
 };
 
 const APPLE_PROVIDER_ID = "apple_intelligence";
@@ -38,6 +45,7 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     updatePostProcessBaseUrl,
     updatePostProcessApiKey,
     updatePostProcessModel,
+    updatePostProcessPricing,
     fetchPostProcessModels,
     postProcessModelOptions,
     postProcessFetchErrors,
@@ -211,6 +219,31 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     [clearPostProcessFetchError, selectedProviderId],
   );
 
+  const inputPrice =
+    settings?.post_process_input_prices?.[selectedProviderId] ?? 0;
+  const outputPrice =
+    settings?.post_process_output_prices?.[selectedProviderId] ?? 0;
+
+  const handlePricingChange = useCallback(
+    (newInputPrice: number, newOutputPrice: number) => {
+      void updatePostProcessPricing(
+        selectedProviderId,
+        newInputPrice,
+        newOutputPrice,
+      );
+    },
+    [selectedProviderId, updatePostProcessPricing],
+  );
+
+  const isPricingUpdating = isUpdating(
+    `post_process_pricing:${selectedProviderId}`,
+  );
+
+  const { autoPricing, isLoading: isAutoLoading } = useModelPricing(
+    selectedProviderId,
+    model,
+  );
+
   // No automatic fetching - user must click refresh button
 
   return {
@@ -236,5 +269,11 @@ export const usePostProcessProviderState = (): PostProcessProviderState => {
     handleProviderSelect,
     handleModelSelect,
     handleRefreshModels,
+    inputPrice,
+    outputPrice,
+    handlePricingChange,
+    isPricingUpdating,
+    autoPricing,
+    isAutoLoading,
   };
 };

--- a/src/components/settings/post-processing/PostProcessingSettings.tsx
+++ b/src/components/settings/post-processing/PostProcessingSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, ArrowsClockwise, X, CaretDown, Plus } from "@phosphor-icons/react";
+import { Check, ArrowsClockwise, X, CaretDown, Plus, Info } from "@phosphor-icons/react";
 import { motion } from "motion/react";
 import { commands } from "@/bindings";
 import type { ShortcutBinding } from "@/bindings";
@@ -14,6 +14,7 @@ import {
   SettingsGroup,
   Textarea,
 } from "@/components/ui";
+import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { ResetButton } from "@/components/ui/ResetButton";
 import { ProviderSelect } from "@/components/settings/PostProcessingSettingsApi/ProviderSelect";
 import { BaseUrlField } from "@/components/settings/PostProcessingSettingsApi/BaseUrlField";
@@ -21,6 +22,7 @@ import { ApiKeyField } from "@/components/settings/PostProcessingSettingsApi/Api
 import { ModelSelect } from "@/components/settings/PostProcessingSettingsApi/ModelSelect";
 import { usePostProcessProviderState } from "@/components/settings/PostProcessingSettingsApi/usePostProcessProviderState";
 import { useSettings } from "@/hooks/useSettings";
+import { useModelPricing } from "@/hooks/useModelPricing";
 import { usePostProcessStats } from "@/hooks/usePostProcessStats";
 import { spring } from "@/lib/motion";
 import { formatKeyCombination, type OSType } from "@/lib/utils/keyboard";
@@ -28,6 +30,15 @@ import { useOsType } from "@/hooks/useOsType";
 
 const BUILTIN_PROMPT_PREFIX = "default_";
 const CREATING_ID = "__creating__";
+
+/** Rough token estimate: ~4 characters per token (works for English text). */
+const estimateTokens = (text: string): number =>
+  Math.ceil(text.length / 4);
+
+/** Average transcript assumptions (100-word dictation). */
+const AVG_TRANSCRIPT_INPUT_TOKENS = 140;
+const AVG_TRANSCRIPT_OUTPUT_TOKENS = 120;
+const USER_MESSAGE_OVERHEAD_TOKENS = 3; // "Transcript: " prefix
 const FIELD_WIDTH = "w-[260px]";
 
 /** Reusable clickable row with animated caret for expand/collapse sections. */
@@ -75,6 +86,113 @@ const FieldAlignmentSpacer = ({ children }: { children?: React.ReactNode }) => (
     {children}
   </div>
 );
+
+/** Inline pricing inputs with computed $/M requests estimate. */
+const PricingFields: React.FC<{
+  inputPrice: number;
+  outputPrice: number;
+  autoInputPrice: number | null;
+  autoOutputPrice: number | null;
+  onPricingChange: (inputPrice: number, outputPrice: number) => void;
+  disabled?: boolean;
+}> = ({
+  inputPrice,
+  outputPrice,
+  autoInputPrice,
+  autoOutputPrice,
+  onPricingChange,
+  disabled,
+}) => {
+  const { t } = useTranslation();
+  const [localInput, setLocalInput] = useState(
+    inputPrice > 0 ? String(inputPrice) : "",
+  );
+  const [localOutput, setLocalOutput] = useState(
+    outputPrice > 0 ? String(outputPrice) : "",
+  );
+
+  // Sync local state when external values change (e.g. provider switch)
+  useEffect(() => {
+    setLocalInput(inputPrice > 0 ? String(inputPrice) : "");
+    setLocalOutput(outputPrice > 0 ? String(outputPrice) : "");
+  }, [inputPrice, outputPrice]);
+
+  const commitPricing = (rawInput: string, rawOutput: string) => {
+    const ip = parseFloat(rawInput) || 0;
+    const op = parseFloat(rawOutput) || 0;
+    if (ip !== inputPrice || op !== outputPrice) {
+      onPricingChange(Math.max(0, ip), Math.max(0, op));
+    }
+  };
+
+  // Placeholders: show auto-fetched price if available, otherwise generic hint
+  const inputPlaceholder =
+    autoInputPrice != null && autoInputPrice > 0
+      ? String(autoInputPrice)
+      : t("settings.postProcessing.api.pricing.inputPlaceholder");
+  const outputPlaceholder =
+    autoOutputPrice != null && autoOutputPrice > 0
+      ? String(autoOutputPrice)
+      : t("settings.postProcessing.api.pricing.outputPlaceholder");
+
+  const isUsingAuto =
+    (autoInputPrice != null || autoOutputPrice != null) &&
+    !localInput &&
+    !localOutput;
+
+  return (
+    <SettingContainer
+      title={t("settings.postProcessing.api.pricing.title")}
+      description={t("settings.postProcessing.api.pricing.description")}
+      descriptionMode="tooltip"
+      layout="horizontal"
+      grouped={true}
+    >
+      <div className="flex items-center gap-2">
+        <div className={`flex items-center gap-2 ${FIELD_WIDTH}`}>
+          <div className="flex items-center gap-1.5 flex-1 min-w-0">
+            <label className="text-[11px] text-muted/50 whitespace-nowrap">
+              {t("settings.postProcessing.api.pricing.inputPrice")}
+            </label>
+            <Input
+              type="text"
+              inputMode="decimal"
+              value={localInput}
+              onChange={(e) => setLocalInput(e.target.value)}
+              onBlur={() => commitPricing(localInput, localOutput)}
+              placeholder={inputPlaceholder}
+              disabled={disabled}
+              className="flex-1 min-w-0 text-xs"
+              variant="compact"
+            />
+          </div>
+          <div className="flex items-center gap-1.5 flex-1 min-w-0">
+            <label className="text-[11px] text-muted/50 whitespace-nowrap">
+              {t("settings.postProcessing.api.pricing.outputPrice")}
+            </label>
+            <Input
+              type="text"
+              inputMode="decimal"
+              value={localOutput}
+              onChange={(e) => setLocalOutput(e.target.value)}
+              onBlur={() => commitPricing(localInput, localOutput)}
+              placeholder={outputPlaceholder}
+              disabled={disabled}
+              className="flex-1 min-w-0 text-xs"
+              variant="compact"
+            />
+          </div>
+        </div>
+        <FieldAlignmentSpacer />
+      </div>
+      {isUsingAuto && (
+        <p className="text-[11px] text-muted/40 mt-1">
+          {t("settings.postProcessing.api.pricing.autoFetched")}
+        </p>
+      )}
+    </SettingContainer>
+  );
+};
 
 const PostProcessingSettingsApiComponent: React.FC = () => {
   const { t } = useTranslation();
@@ -297,6 +415,17 @@ const PostProcessingSettingsApiComponent: React.FC = () => {
             </SettingContainer>
           )}
 
+          {!state.isAppleProvider && (
+            <PricingFields
+              inputPrice={state.inputPrice}
+              outputPrice={state.outputPrice}
+              autoInputPrice={state.autoPricing?.input ?? null}
+              autoOutputPrice={state.autoPricing?.output ?? null}
+              onPricingChange={state.handlePricingChange}
+              disabled={state.isPricingUpdating}
+            />
+          )}
+
           {statsLine && (
             <div className="px-3 py-2">
               <p className="text-xs text-muted/70">{statsLine}</p>
@@ -396,6 +525,60 @@ const PromptFields: React.FC<PromptFieldsProps> = ({
   );
 };
 
+/** Cost estimation badge for a prompt row, with tooltip showing assumptions. */
+const PromptCostEstimate: React.FC<{
+  promptText: string;
+  inputPrice: number;
+  outputPrice: number;
+}> = ({ promptText, inputPrice, outputPrice }) => {
+  const { t } = useTranslation();
+
+  const estimate = useMemo(() => {
+    const systemTokens = estimateTokens(promptText);
+    const totalInputTokens =
+      systemTokens + AVG_TRANSCRIPT_INPUT_TOKENS + USER_MESSAGE_OVERHEAD_TOKENS;
+    const totalOutputTokens = AVG_TRANSCRIPT_OUTPUT_TOKENS;
+
+    const costPerRequest =
+      (totalInputTokens * inputPrice + totalOutputTokens * outputPrice) /
+      1_000_000;
+    if (costPerRequest <= 0) return null;
+
+    const requestsPerDollar = Math.floor(1 / costPerRequest);
+
+    return {
+      count: requestsPerDollar,
+      systemTokens,
+      totalInputTokens,
+      totalOutputTokens,
+    };
+  }, [promptText, inputPrice, outputPrice]);
+
+  if (!estimate || estimate.count <= 0) return null;
+
+  return (
+    <SimpleTooltip
+      content={
+        <p className="max-w-[280px] text-left whitespace-pre-line">
+          {t("settings.postProcessing.prompts.costTooltip", {
+            systemTokens: estimate.systemTokens,
+            totalInputTokens: estimate.totalInputTokens,
+            totalOutputTokens: estimate.totalOutputTokens,
+          })}
+        </p>
+      }
+      side="bottom"
+    >
+      <span className="text-[11px] text-muted/40 truncate flex items-center gap-1 cursor-help">
+        <Info size={10} />
+        {t("settings.postProcessing.prompts.costEstimate", {
+          requests: estimate.count.toLocaleString(),
+        })}
+      </span>
+    </SimpleTooltip>
+  );
+};
+
 const PostProcessingSettingsPromptsComponent = React.forwardRef<{
   startCreate: () => void;
 }>(function PostProcessingSettingsPromptsComponent(_, ref) {
@@ -410,6 +593,17 @@ const PostProcessingSettingsPromptsComponent = React.forwardRef<{
   const [formError, setFormError] = useState<string | null>(null);
 
   const prompts = getSetting("post_process_prompts") || [];
+  const providerId = getSetting("post_process_provider_id") || "";
+  const modelId = getSetting("post_process_models")?.[providerId] ?? "";
+  const manualInput =
+    getSetting("post_process_input_prices")?.[providerId] ?? 0;
+  const manualOutput =
+    getSetting("post_process_output_prices")?.[providerId] ?? 0;
+  const { autoPricing } = useModelPricing(providerId, modelId);
+  const inputPrice = manualInput > 0 ? manualInput : (autoPricing?.input ?? 0);
+  const outputPrice =
+    manualOutput > 0 ? manualOutput : (autoPricing?.output ?? 0);
+  const hasPricing = inputPrice > 0 || outputPrice > 0;
   const bindings = (getSetting("bindings") || {}) as Record<
     string,
     ShortcutBinding
@@ -551,6 +745,13 @@ const PostProcessingSettingsPromptsComponent = React.forwardRef<{
                   <span className="text-xs text-muted/50 truncate block">
                     {prompt.prompt.split("\n")[0]}
                   </span>
+                )}
+                {!isExpanded && hasPricing && (
+                  <PromptCostEstimate
+                    promptText={prompt.prompt}
+                    inputPrice={inputPrice}
+                    outputPrice={outputPrice}
+                  />
                 )}
               </div>
             </CollapsibleRow>

--- a/src/hooks/useModelPricing.ts
+++ b/src/hooks/useModelPricing.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { commands, type ModelPricing } from "@/bindings";
+
+/**
+ * Looks up auto-pricing for a provider + model from models.dev.
+ * Returns null when unavailable (unknown model, network error, etc.).
+ */
+export function useModelPricing(
+  providerId: string,
+  modelId: string,
+): { autoPricing: ModelPricing | null; isLoading: boolean } {
+  const [autoPricing, setAutoPricing] = useState<ModelPricing | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (
+      !providerId ||
+      !modelId ||
+      providerId === "custom" ||
+      providerId === "apple_intelligence"
+    ) {
+      setAutoPricing(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    commands
+      .lookupModelPricing(providerId, modelId)
+      .then((result) => {
+        if (cancelled) return;
+        setAutoPricing(result.status === "ok" ? result.data : null);
+      })
+      .catch(() => {
+        if (!cancelled) setAutoPricing(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId, modelId]);
+
+  return { autoPricing, isLoading };
+}

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -390,6 +390,15 @@
           "refreshModels": "تحديث النماذج"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "تم التحقق"
       },
       "prompts": {
@@ -412,6 +421,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Obnovit modely"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Ověřeno"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Modelle aktualisieren"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Verifiziert"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -468,7 +468,16 @@
           "placeholderNoOptions": "Type a model name",
           "refreshModels": "Refresh models"
         },
-        "tokensPerSecond": "{{value}} tok/s"
+        "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        }
       },
       "prompts": {
         "title": "Prompt",
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Actualizar modelos"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Verificado"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Actualiser les modèles"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Vérifié"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Aggiorna modelli"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Verificato"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "モデルを更新"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "確認済み"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "모델 새로고침"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "인증됨"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Odśwież modele"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Zweryfikowano"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Atualizar modelos"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Verificado"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Обновить модели"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Подтверждено"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Modelleri Yenile"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Doğrulandı"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Оновити моделі"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Перевірено"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "Làm mới mô hình"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "Đã xác minh"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "重新整理模型"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "已驗證"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -468,6 +468,15 @@
           "refreshModels": "刷新模型"
         },
         "tokensPerSecond": "{{value}} tok/s",
+        "pricing": {
+          "title": "Pricing",
+          "description": "Enter your provider's pricing to see cost estimates.",
+          "inputPrice": "Input $/M",
+          "outputPrice": "Output $/M",
+          "inputPlaceholder": "e.g. 0.15",
+          "outputPlaceholder": "e.g. 0.60",
+          "autoFetched": "Auto-fetched from models.dev"
+        },
         "verified": "已验证"
       },
       "prompts": {
@@ -490,6 +499,8 @@
         "createFirstHint": "Create your first one below.",
         "builtIn": "Built-in",
         "builtInReadOnly": "Built-in prompts are read-only.",
+        "costEstimate": "~{{requests}} requests per $1",
+        "costTooltip": "System prompt: ~{{systemTokens}} tokens. Assumes avg 100-word transcript (~140 input tokens, ~120 output tokens). Total per request: ~{{totalInputTokens}} input + ~{{totalOutputTokens}} output tokens.",
         "errorCreate": "Failed to create prompt. Please try again.",
         "errorUpdate": "Failed to update prompt. Please try again.",
         "errorDelete": "Failed to delete prompt. Please try again."

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -59,6 +59,11 @@ interface SettingsStore {
   fetchPostProcessModels: (providerId: string) => Promise<string[]>;
   setPostProcessModelOptions: (providerId: string, models: string[]) => void;
   clearPostProcessFetchError: (providerId: string) => void;
+  updatePostProcessPricing: (
+    providerId: string,
+    inputPrice: number,
+    outputPrice: number,
+  ) => Promise<void>;
 
   // STT provider helpers
   setSttProvider: (providerId: string) => Promise<void>;
@@ -632,6 +637,22 @@ export const useSettingsStore = create<SettingsStore>()(
         const { [providerId]: _, ...rest } = state.postProcessFetchErrors;
         return { postProcessFetchErrors: rest };
       }),
+
+    updatePostProcessPricing: async (providerId, inputPrice, outputPrice) => {
+      const { setUpdating, refreshSettings } = get();
+      const updateKey = `post_process_pricing:${providerId}`;
+
+      setUpdating(updateKey, true);
+
+      try {
+        await commands.setPostProcessPricing(providerId, inputPrice, outputPrice);
+        await refreshSettings();
+      } catch (error) {
+        console.error("Failed to update post-process pricing:", error);
+      } finally {
+        setUpdating(updateKey, false);
+      }
+    },
 
     setSttProvider: async (providerId) => {
       const { settings, setUpdating, refreshSettings } = get();


### PR DESCRIPTION
## Summary

- Adds per-provider input/output pricing fields in post-processing settings, with auto-fetch from models.dev for known models
- Stores pricing in settings as `post_process_input_prices` / `post_process_output_prices` maps (Rust + Zustand)
- Displays cost-per-request estimates on prompt cards (e.g. "~500 requests per $1") with a tooltip explaining token assumptions
- New Tauri commands: `set_post_process_pricing` and `lookup_model_pricing`
- i18n keys added to all 16 locales

## Test plan

- [ ] Open post-processing settings, select an OpenAI-compatible provider — pricing fields appear
- [ ] Select a known model — fields auto-populate from models.dev
- [ ] Manually enter pricing — cost estimate updates on prompt cards
- [ ] Verify tooltip explains token breakdown
- [ ] Check all translations pass: `bun run check:translations`