### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "handless-app",
   "private": true,
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "description": "macOS desktop speech-to-text. Private, offline, open-source.",
   "keywords": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Handless",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "com.handless.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- Bump version from 0.1.9 to 0.1.10 in `package.json` and `src-tauri/tauri.conf.json`

## Test plan
- [ ] Verify version displays correctly in the app
- [ ] Trigger release workflow to build and publish v0.1.10