### PR TITLE
fix: normalize persisted settings and add agent docs

### DIFF
--- a/.agents/skills/add-cloud-stt-provider/SKILL.md
+++ b/.agents/skills/add-cloud-stt-provider/SKILL.md
@@ -1,0 +1,387 @@
+---
+name: add-cloud-stt-provider
+description: Add a new cloud speech-to-text provider to Handless. Use when integrating a new cloud STT API (e.g., Google Cloud STT, Azure Speech, Rev AI). Covers Rust backend, provider registration, settings defaults, dictionary injection, realtime WebSocket support, and i18n across all 17 locales.
+---
+
+# Add Cloud STT Provider
+
+This skill walks through every file and code change needed to add a new cloud speech-to-text provider to Handless. Follow every step exactly — skipping any step will cause compilation errors or runtime failures.
+
+Before starting, research the provider's API documentation to understand:
+
+- Authentication method (usually Bearer token)
+- Transcription endpoint(s) and request format
+- Response shape (where the transcribed text lives)
+- Available parameters (language, model variants, etc.)
+- Supported languages (ISO 639-1 codes)
+- Whether it supports streaming/realtime via WebSocket
+- Whether it's OpenAI-compatible (same endpoint format, multipart form, response shape)
+
+## Step 1: Create the provider module
+
+Create `src-tauri/src/cloud_stt/<provider_name>.rs`.
+
+### OpenAI-compatible shortcut
+
+If the provider uses an OpenAI-compatible API (same `/audio/transcriptions` endpoint, same multipart form fields, same `{ "text": "..." }` response — like Groq), you can skip writing a full module and just re-export:
+
+```rust
+/// <Provider>'s STT API is fully OpenAI-compatible.
+/// We delegate directly to the OpenAI implementation since `base_url` already differentiates them.
+pub use super::openai::{test_api_key, transcribe};
+```
+
+This works because `base_url` is passed as a parameter and distinguishes the provider. Only use this if the API is truly identical — if there are any extra parameters (like Fireworks' `diarize` field), write a dedicated module.
+
+### Full implementation
+
+Every provider must implement exactly two public async functions with these signatures:
+
+```rust
+pub async fn test_api_key(api_key: &str, base_url: &str, model: &str) -> Result<()>
+
+pub async fn transcribe(
+    api_key: &str,
+    base_url: &str,
+    model: &str,
+    audio_wav: Vec<u8>,
+    options: Option<&serde_json::Value>,
+) -> Result<String>
+```
+
+### Shared helpers (use these, don't rewrite)
+
+The following helpers are defined in `src-tauri/src/cloud_stt/mod.rs` — use them instead of writing inline equivalents:
+
+- **`super::test_silence_wav()?`** — generates a minimal silent WAV for API key validation. Use instead of `crate::audio_toolkit::audio::encode_wav_bytes(&vec![0.0f32; 1600])?`
+- **`super::check_response(response, "Provider error context").await?`** — checks HTTP status and returns a formatted error with status code and body. Use instead of the inline `if !response.status().is_success() { ... }` pattern
+- **`super::TranscriptionResponse`** — shared `{ text: String }` deserialization struct. Use for providers whose response has a top-level `text` field (OpenAI, Fireworks, Cartesia, ElevenLabs, Mistral)
+- **`super::strip_lang_subtag(lang)`** — strips language subtags like `"zh-Hans"` → `"zh"`. Use for providers that expect ISO 639-1 codes without subtags
+
+### test_api_key
+
+Validates credentials by sending a minimal request. Pattern:
+
+1. Generate a tiny silent WAV: `super::test_silence_wav()?`
+2. Send it to the provider's API with the given `api_key` and `model`
+3. Use `super::check_response(response, "Provider test error").await?` to validate the response
+
+### transcribe
+
+Transcribes real audio. Pattern:
+
+1. `audio_wav` is already WAV-encoded bytes — send directly
+2. Extract provider-specific options from `options: Option<&serde_json::Value>` using `.get("key").and_then(|v| v.as_str())` etc.
+3. Make the API call using `reqwest::Client`
+4. Use `super::check_response(...)` for error handling
+5. Deserialize the response (use `super::TranscriptionResponse` if applicable) and return the transcribed text
+6. Use `debug!()` for logging request params and results
+
+### Reference implementations
+
+- **Simple multipart POST** — `openai.rs`: single POST to `/audio/transcriptions`
+- **Multi-step (upload → create → poll)** — `assemblyai.rs`: upload audio, create transcript, poll until done
+- **Binary body (not multipart)** — `deepgram.rs`: raw audio body with query params
+- **Custom auth header** — `elevenlabs.rs`: uses `xi-api-key` header instead of Bearer
+- **Re-export** — `groq.rs`: 3-line file delegating to OpenAI
+
+## Step 2: Register in the dispatch module
+
+Edit `src-tauri/src/cloud_stt/mod.rs`.
+
+1. Add the module declaration at the top:
+
+```rust
+pub mod <provider_name>;
+```
+
+2. Add match arms in both functions:
+
+```rust
+// In test_api_key():
+"<provider_id>" => <provider_name>::test_api_key(api_key, base_url, model).await,
+
+// In transcribe():
+"<provider_id>" => <provider_name>::transcribe(api_key, base_url, model, audio_wav, options).await,
+```
+
+The `provider_id` is a unique string identifier (e.g., `"deepgram"`, `"assemblyai"`). It must be consistent across all files.
+
+## Step 3: Add to the provider registry
+
+Edit `src-tauri/src/stt_provider.rs` — add a new entry to the `cloud_provider_registry()` vec.
+
+```rust
+SttProviderInfo {
+    id: "<provider_id>".to_string(),
+    name: "<Display Name>".to_string(),
+    description: "onboarding.cloud.<provider_id>.description".to_string(),
+    supported_languages: vec![
+        // ISO 639-1 codes the provider supports
+        // Use "zh-Hans"/"zh-Hant" for Chinese variants
+    ].into_iter().map(String::from).collect(),
+    supports_translation: false,        // Can it translate audio to English?
+    supports_realtime: false,           // ONLY set true if Step 7 (realtime) is implemented
+    is_recommended: false,
+    backend: ProviderBackend::Cloud {
+        base_url: "<default API base URL>".to_string(),
+        default_model: "<default model name>".to_string(),
+        console_url: Some("<URL where users get API keys>".to_string()),
+    },
+    available_options: vec![
+        // Provider-specific options rendered in the settings UI.
+        // Each option generates a UI control automatically.
+        // Use i18n keys for label and description.
+        //
+        // Option types:
+        //   CloudOptionType::Language       — single language dropdown
+        //   CloudOptionType::LanguageMulti  — multi-select language picker
+        //   CloudOptionType::Text           — freeform text input
+        //   CloudOptionType::Number { min, max, step } — numeric slider
+        //   CloudOptionType::Boolean        — toggle switch
+        //
+        // Example:
+        // CloudProviderOption {
+        //     key: "language".to_string(),
+        //     label: "settings.models.cloudProviders.options.language".to_string(),
+        //     option_type: CloudOptionType::Language,
+        //     description: String::new(),
+        // },
+    ],
+    supports_dictionary_terms: false,   // Set true if provider can use glossary terms
+    supports_dictionary_context: false, // Set true if provider can use context text
+},
+```
+
+### Important notes
+
+- The `key` field in options must match exactly what you read from `options` in the `transcribe()` function
+- Reuse existing i18n keys when possible (e.g., `settings.models.cloudProviders.options.language` is already shared)
+- **`supports_realtime` must be `false` unless you implement Step 7** — this flag gates UI functionality that routes to WebSocket code. Setting it `true` without a matching realtime client causes runtime errors.
+
+## Step 4: Add settings defaults
+
+Edit `src-tauri/src/settings.rs` — add an entry to `default_stt_providers()`:
+
+```rust
+SttProvider {
+    id: "<provider_id>".to_string(),
+    label: "<Display Name>".to_string(),
+    provider_type: SttProviderType::Cloud,
+    base_url: "<default API base URL>".to_string(),
+    default_model: "<default model name>".to_string(),
+},
+```
+
+The `base_url` and `default_model` must match the values in `cloud_provider_registry()`.
+
+No other settings changes needed — `default_stt_api_keys()`, `default_stt_cloud_models()`, `default_stt_cloud_options()`, and `ensure_stt_defaults()` all iterate over `default_stt_providers()` automatically.
+
+## Step 5: Add dictionary injection (if supported)
+
+If the provider supports dictionary terms or context, edit the `inject_dictionary()` function in `src-tauri/src/stt_provider.rs`.
+
+Add a new match arm in the `match provider_id { ... }` block. Existing patterns:
+
+- **Prompt-based** (`"openai_stt" | "groq" | "fireworks"`): prepend glossary to a `prompt` text field
+- **Keyword array** (`"deepgram"`): merge into a `keyterm` comma-separated field
+- **JSON array** (`"assemblyai"`): merge into a `keyterms_prompt` JSON array
+- **Comma-separated** (`"mistral"`): merge into a `context_bias` text field
+- **Dedicated fields** (`"soniox"`): merge into `context_terms` and `context_description` separately
+- **JSON array** (`"elevenlabs"`): merge into a `keyterms` JSON array
+
+If the provider does NOT support dictionary injection, skip this step — the default `_` arm handles unknown providers with a debug log.
+
+## Step 6: Add i18n translations
+
+### 6a. English translations
+
+Edit `src/i18n/locales/en/translation.json`. Add two groups of keys:
+
+**Provider identity** (under `onboarding.cloud`):
+
+```json
+"<provider_id>": {
+  "name": "<Display Name>",
+  "description": "<One-line description of the provider's strengths>"
+}
+```
+
+**Provider-specific option labels** (under `settings.models.cloudProviders.options`) — only for NEW option keys not already present:
+
+```json
+"<optionKey>": "<Label text>",
+"<optionKey>Description": "<Help text>"
+```
+
+Reuse existing keys when the option is semantically identical to one already defined (e.g., `language`, `prompt`, `temperature`, `enableSpeakerDiarization`).
+
+### 6b. All other locales
+
+Add the **exact same keys** with **English text as placeholder** to all 16 other locale files:
+
+- `src/i18n/locales/ar/translation.json`
+- `src/i18n/locales/cs/translation.json`
+- `src/i18n/locales/de/translation.json`
+- `src/i18n/locales/es/translation.json`
+- `src/i18n/locales/fr/translation.json`
+- `src/i18n/locales/it/translation.json`
+- `src/i18n/locales/ja/translation.json`
+- `src/i18n/locales/ko/translation.json`
+- `src/i18n/locales/pl/translation.json`
+- `src/i18n/locales/pt/translation.json`
+- `src/i18n/locales/ru/translation.json`
+- `src/i18n/locales/tr/translation.json`
+- `src/i18n/locales/uk/translation.json`
+- `src/i18n/locales/vi/translation.json`
+- `src/i18n/locales/zh/translation.json`
+- `src/i18n/locales/zh-TW/translation.json`
+
+### 6c. Verify
+
+Run:
+
+```bash
+bun run check:translations
+```
+
+This must pass with zero missing/extra keys.
+
+## Step 7: Add realtime support (optional)
+
+Only if the provider supports WebSocket-based streaming transcription. **Skip this entirely if the provider is batch-only.**
+
+### 7a. Create the realtime module
+
+Create `src-tauri/src/cloud_stt/realtime/<provider_name>.rs` with three public functions:
+
+```rust
+pub async fn test_api_key(api_key: &str, model: &str) -> Result<()>
+
+pub async fn transcribe(
+    api_key: &str,
+    model: &str,
+    audio_wav: Vec<u8>,
+    options: Option<&serde_json::Value>,
+) -> Result<String>
+
+pub async fn start_streaming(
+    api_key: &str,
+    model: &str,
+    audio_rx: tokio::sync::mpsc::Receiver<Vec<f32>>,
+    options: Option<serde_json::Value>,
+    delta_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+) -> Result<StreamingHandles>
+```
+
+Note: realtime functions do NOT take `base_url` — WebSocket URLs are typically hardcoded constants since they differ from REST base URLs.
+
+### Key implementation details
+
+**WebSocket connection with custom headers:** Use `IntoClientRequest` to build the request — do NOT use raw `Request::builder()` which omits required WebSocket upgrade headers:
+
+```rust
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+fn build_ws_request(api_key: &str, url: &str) -> Result<tungstenite::http::Request<()>> {
+    let mut request = url.into_client_request()?;
+    request.headers_mut().insert("Authorization", format!("Bearer {}", api_key).parse()?);
+    Ok(request)
+}
+```
+
+If a provider requires manually constructed headers (e.g., `Host`, non-standard auth), you may use `Request::builder()` but MUST include `Connection: Upgrade`, `Upgrade: websocket`, `Sec-WebSocket-Version: 13`, and `Sec-WebSocket-Key` (via `tungstenite::handshake::client::generate_key()`). See `realtime/fireworks.rs` or `realtime/mistral.rs` for this pattern.
+
+**Audio format:** Convert f32 frames to i16 LE PCM bytes:
+
+```rust
+let bytes: Vec<u8> = frame.iter()
+    .map(|&s| (s.clamp(-1.0, 1.0) * i16::MAX as f32) as i16)
+    .flat_map(|s| s.to_le_bytes())
+    .collect();
+```
+
+**`start_streaming` pattern:** Spawn two tokio tasks returning `StreamingHandles`:
+
+- **Sender task**: reads f32 audio from `audio_rx`, converts to PCM, sends via WebSocket
+- **Reader task**: reads WebSocket messages, accumulates final text, sends live preview via `delta_tx`
+
+**Delta preview:** Send `final_text + interim_text` via `delta_tx` on every message for live UI updates.
+
+### Reference implementations (by protocol type)
+
+- **Binary PCM frames** — `realtime/deepgram.rs`, `realtime/assemblyai.rs`: send raw binary, `CloseStream`/`Terminate` JSON to end
+- **Base64 JSON messages** — `realtime/elevenlabs.rs`, `realtime/mistral.rs`, `realtime/openai.rs`: audio encoded as base64 in JSON text frames
+- **Segment-based responses** — `realtime/fireworks.rs`: tracks segments by ID in a BTreeMap
+
+### 7b. Register in realtime dispatch
+
+Edit `src-tauri/src/cloud_stt/realtime/mod.rs`:
+
+- Add `mod <provider_name>;`
+- Add match arms in both `test_api_key()` and `transcribe()`
+
+### 7c. Register in session dispatch
+
+Edit `src-tauri/src/cloud_stt/realtime/session.rs`:
+
+- Add a match arm in `RealtimeStreamingSession::start()` using the existing macro:
+
+```rust
+"<provider_id>" => start_provider!(<provider_name>),
+```
+
+### 7d. Set the flag
+
+Set `supports_realtime: true` in the `cloud_provider_registry()` entry (Step 3).
+
+## Step 8: Verify
+
+Run these checks:
+
+```bash
+# Rust compilation
+cargo check --manifest-path src-tauri/Cargo.toml
+
+# Clippy
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+
+# Rust formatting
+cd src-tauri && cargo fmt --check && cd ..
+
+# Translation keys
+bun run check:translations
+
+# TypeScript (bindings regenerate during cargo check)
+npx tsc --noEmit
+
+# Lint
+bun run lint
+```
+
+All must pass. The specta bindings (`src/bindings.ts`) auto-regenerate during `cargo check` — no manual changes needed.
+
+## What you do NOT need to change
+
+The following are fully generic and require zero modifications:
+
+- **Frontend components** — `CloudProviderConfigCard.tsx` renders all providers dynamically from the registry
+- **Tauri commands** — `test_stt_api_key`, `get_all_stt_providers`, `change_stt_cloud_options_setting` are provider-agnostic
+- **TypeScript bindings** — auto-generated by specta from Rust types
+- **Model store** — fetches providers via `getAllSttProviders()` command
+- **Transcription manager** — dispatches to the correct provider via the `cloud_stt::transcribe()` function
+- **Settings persistence** — `ensure_stt_defaults()` automatically picks up new providers from `default_stt_providers()`
+
+## File checklist
+
+| #   | File                                                                                     | Action                                                |
+| --- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| 1   | `src-tauri/src/cloud_stt/<provider>.rs`                                                  | Create (or 3-line re-export for OpenAI-compatible)    |
+| 2   | `src-tauri/src/cloud_stt/mod.rs`                                                         | Edit (module + match arms)                            |
+| 3   | `src-tauri/src/stt_provider.rs`                                                          | Edit (registry entry + optional dictionary injection) |
+| 4   | `src-tauri/src/settings.rs`                                                              | Edit (default_stt_providers)                          |
+| 5   | `src/i18n/locales/en/translation.json`                                                   | Edit (provider + option keys)                         |
+| 6   | `src/i18n/locales/{ar,cs,de,es,fr,it,ja,ko,pl,pt,ru,tr,uk,vi,zh,zh-TW}/translation.json` | Edit (same keys, English placeholder)                 |
+| 7   | `src-tauri/src/cloud_stt/realtime/<provider>.rs`                                         | Create (only if realtime)                             |
+| 8   | `src-tauri/src/cloud_stt/realtime/mod.rs`                                                | Edit (only if realtime)                               |
+| 9   | `src-tauri/src/cloud_stt/realtime/session.rs`                                            | Edit (only if realtime — add match arm)               |

--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: architecture
+description: Handless app architecture, project structure, and core patterns. Use when understanding or modifying the app's structure, data flow, module responsibilities, or adding new features that span backend and frontend.
+---
+
+# Handless Architecture
+
+Tauri 2.x desktop speech-to-text app: Rust backend + React/TypeScript frontend.
+
+## Core Pipeline
+
+Audio (CPAL) -> VAD (Silero) -> STT Provider (local Whisper/Parakeet/Moonshine/SenseVoice or cloud) -> Post-processing (LLM) -> Output (Clipboard/Paste/Overlay)
+
+## Key Patterns
+
+- **Manager Pattern**: Core functionality in `managers/` (audio, model, transcription, history), initialized at startup via Tauri managed state
+- **TranscriptionCoordinator**: Serializes all transcription lifecycle events through a single thread to eliminate race conditions (Recording/Processing/Idle states)
+- **Command-Event IPC**: Frontend -> Backend via Tauri commands (type-safe via specta); Backend -> Frontend via events
+- **State**: Zustand stores (frontend) -> Tauri commands -> Rust managed state -> SQLite/tauri-plugin-store (persistence)
+
+## Backend (`src-tauri/src/`)
+
+### Core Orchestration
+
+- `lib.rs` - App entry point, Tauri setup, plugin registration
+- `main.rs` - CLI arg parsing, launches `run()`
+- `actions.rs` - Transcription pipeline action handlers, streaming sessions, drop guards
+- `transcription_coordinator.rs` - Single-threaded event serialization for transcription lifecycle
+- `settings.rs` - AppSettings struct, persistence, custom deserializers
+
+### Managers (`managers/`)
+
+- `audio.rs` - Recording, VAD integration, system audio mute/unmute, clamshell detection
+- `model.rs` - Model download/extraction, engine types, state tracking
+- `transcription.rs` - STT coordination, provider integration
+- `history.rs` - SQLite history DB, migrations, audio file storage
+
+### Commands (`commands/`)
+
+- `mod.rs` - Core commands (cancel, settings, shortcuts, enigo init)
+- `audio.rs` - Device listing, audio settings
+- `models.rs` - Model management commands
+- `transcription.rs` - Transcription control
+- `history.rs` - History CRUD
+
+### Audio (`audio_toolkit/`)
+
+- `audio/` - CPAL-based recording, device enumeration
+- `vad/` - Silero VAD with smoothing wrapper
+- `text.rs` - Output filtering, custom word replacement
+
+### STT Providers
+
+- `stt_provider.rs` - Provider abstraction (local vs cloud)
+- `cloud_stt/` - Cloud integrations (OpenAI, Soniox realtime via WebSocket)
+- `apple_intelligence.rs` - macOS ARM64 Apple Intelligence provider
+
+### Post-Processing (`post_process/`)
+
+- `client.rs` - HTTP client for LLM calls
+- `process.rs` - Post-processing pipeline
+- `prompts.rs` - Builtin correction/prefix prompts
+- `providers.rs` - Provider definitions
+- `commands.rs` - Post-process Tauri commands
+
+### Platform & UI
+
+- `overlay.rs` - Platform-specific overlay (NSPanel/GTK layer shell/WebviewWindow)
+- `shortcut/` - Global shortcuts + HandyKeys library
+- `input.rs` - Keyboard/mouse simulation via Enigo
+- `clipboard.rs` - Clipboard save/restore (Wayland support via wl-copy)
+- `tray.rs` / `tray_i18n.rs` - System tray with theme detection
+- `device_watcher.rs` - Audio device hot-plug detection
+- `audio_feedback.rs` - Start/stop recording sounds
+- `cli.rs` - CLI flags (clap derive)
+- `signal_handle.rs` - Unix signal handlers (SIGUSR1/2)
+
+## Frontend (`src/`)
+
+### State Management
+
+- `stores/settingsStore.ts` - Core settings (Zustand)
+- `stores/modelStore.ts` - Model state, download progress
+
+### Components (`components/`)
+
+- `Sidebar.tsx` - Navigation with section-based routing
+- `settings/general/` - Core settings (language, theme, devices)
+- `settings/models/` - Model selection, downloads
+- `settings/shortcuts/` - Keyboard shortcut config
+- `settings/post-processing/` - LLM text correction
+- `settings/history/` - Transcription history
+- `settings/stats/` - Usage statistics
+- `settings/advanced/` - Advanced settings
+- `settings/debug/` - Debug tools
+- `settings/about/` - App info
+- `model-selector/` - Model selection UI
+- `onboarding/` - First-run flow
+- `update-checker/` - Auto-update
+- `ui/` - 25+ base components (Radix UI + Tailwind)
+
+### Overlay (`overlay/`)
+
+- `RecordingOverlay.tsx` - Streaming transcription display, position-aware
+
+### Utilities
+
+- `bindings.ts` - Auto-generated Tauri command types (specta)
+- `lib/utils/` - Formatting, keyboard display, RTL support
+- `hooks/` - useSettings, useModelActions, useOsType, useTheme, usePostProcessStats

--- a/.agents/skills/cli-parameters/SKILL.md
+++ b/.agents/skills/cli-parameters/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: cli-parameters
+description: CLI flags and remote control parameters for Handless. Use when working with command-line arguments, autostart integration, signal handling, or remote instance control.
+---
+
+# CLI Parameters
+
+Handless supports CLI flags for integration with scripts, window managers, and autostart.
+
+## Flags
+
+| Flag                     | Description                                   |
+| ------------------------ | --------------------------------------------- |
+| `--toggle-transcription` | Toggle recording on/off on a running instance |
+| `--toggle-post-process`  | Toggle recording with post-processing on/off  |
+| `--cancel`               | Cancel current operation                      |
+| `--start-hidden`         | Launch without showing main window            |
+| `--no-tray`              | Launch without system tray icon               |
+| `--debug`                | Enable verbose (Trace) logging                |
+
+## Implementation
+
+- `cli.rs` - Flag definitions (clap derive)
+- `main.rs` - Arg parsing before Tauri launch
+- `lib.rs` - Applying CLI overrides
+- `signal_handle.rs` - `send_transcription_input()` shared between signal handlers and CLI
+
+## Design
+
+- Flags are runtime-only overrides, never persisted
+- Remote control flags (`--toggle-*`, `--cancel`) launch a second instance that sends args via `tauri_plugin_single_instance`, then exits
+- `CliArgs` stored in Tauri managed state for access in event handlers

--- a/.agents/skills/release-check/SKILL.md
+++ b/.agents/skills/release-check/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: release-check
+description: Use before cutting a release to verify build, version, and smoke test.
+---
+
+# Release Check
+
+Pre-release verification for Handless. Run all checks, report pass/fail per item, and block release on any failure.
+
+## Steps
+
+### 1. Version Sync
+
+All three files must contain the **same** version string:
+
+- `src-tauri/tauri.conf.json` → `"version": "X.Y.Z"` (primary source — release workflow reads this)
+- `src-tauri/Cargo.toml` → `version = "X.Y.Z"`
+- `package.json` → `"version": "X.Y.Z"`
+
+Read all three files and compare. Any mismatch is a **Fail**.
+
+### 2. CHANGELOG.md
+
+- `CHANGELOG.md` must have a `## [X.Y.Z] - YYYY-MM-DD` section matching the version from step 1.
+- The `## [Unreleased]` section should be empty (all items moved to the new version section).
+- The version section must have at least one entry under Added, Changed, or Fixed.
+
+### 3. Translation Consistency
+
+Run:
+
+```bash
+bun run check:translations
+```
+
+Non-zero exit code is a **Fail**. Report any missing or extra keys.
+
+### 4. TypeScript Lint & Type Check
+
+Run in parallel:
+
+```bash
+bun run lint
+npx tsc --noEmit
+```
+
+Non-zero exit code on either is a **Fail**.
+
+### 5. Formatting
+
+Run in parallel:
+
+```bash
+bun run format:check
+cd src-tauri && cargo fmt --check
+```
+
+Non-zero exit code on either is a **Fail**.
+
+### 6. Rust Clippy
+
+Run:
+
+```bash
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+```
+
+Non-zero exit code is a **Fail**. Warnings promoted to errors.
+
+### 7. Cargo.lock Sync
+
+Run:
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml --locked
+```
+
+Fails if `Cargo.lock` is out of date with `Cargo.toml`.
+
+### 8. Bindings Up-to-Date
+
+Specta auto-generates `src/bindings.ts` during `cargo check`. After the Rust check in step 7, verify:
+
+```bash
+git diff --name-only src/bindings.ts
+```
+
+If `bindings.ts` has uncommitted changes, bindings are stale — **Fail**.
+
+### 9. Build Smoke Test
+
+Run:
+
+```bash
+bun run tauri build
+```
+
+Non-zero exit code is a **Fail**. This is the slowest step; run it last.
+
+### 10. Clean Working Tree
+
+Run:
+
+```bash
+git status --porcelain
+```
+
+Any uncommitted changes (other than the release commit itself) is a **Fail**. Everything must be committed before triggering the release workflow.
+
+## Output
+
+Print a summary table:
+
+```
+## Release Check: vX.Y.Z
+
+| #  | Check                  | Status |
+|----|------------------------|--------|
+| 1  | Version sync           | Pass   |
+| 2  | CHANGELOG.md           | Pass   |
+| 3  | Translations           | Pass   |
+| 4  | Lint & type check      | Pass   |
+| 5  | Formatting             | Pass   |
+| 6  | Clippy                 | Pass   |
+| 7  | Cargo.lock sync        | Pass   |
+| 8  | Bindings up-to-date    | Pass   |
+| 9  | Build smoke test       | Pass   |
+| 10 | Clean working tree     | Pass   |
+
+Result: READY TO RELEASE ✓
+```
+
+Any **Fail** must be fixed before release. After all checks pass, the release can be triggered via `gh workflow run release.yml`.

--- a/.agents/skills/test-onboarding/SKILL.md
+++ b/.agents/skills/test-onboarding/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: test-onboarding
+description: Force the onboarding page to display during development, even when permissions are already granted. Use when testing or iterating on the onboarding UI.
+---
+
+# Test Onboarding Page
+
+The onboarding screen is skipped when macOS accessibility and microphone permissions are already granted. To force it to show during `bun run tauri dev`, apply all three changes below:
+
+## 1. Force onboarding step in App.tsx
+
+In `src/App.tsx`, inside `checkOnboardingStatus()`, change the final fallback:
+
+```tsx
+// Change:
+setOnboardingStep("done");
+// To:
+setOnboardingStep("accessibility");
+```
+
+## 2. Disable auto-complete in AccessibilityOnboarding.tsx
+
+In `src/components/onboarding/AccessibilityOnboarding.tsx`, inside `checkInitial()`, comment out the early exit when both permissions are already granted:
+
+```tsx
+// Comment out:
+if (accessibilityGranted && microphoneGranted) {
+  await Promise.all([refreshAudioDevices(), refreshOutputDevices()]);
+  timeoutRef.current = setTimeout(() => onComplete(), 300);
+}
+```
+
+## 3. Force permissions to "needed"
+
+In the same `checkInitial()` function, force the permission state:
+
+```tsx
+// Change:
+const newState: PermissionsState = {
+  accessibility: accessibilityGranted ? "granted" : "needed",
+  microphone: microphoneGranted ? "granted" : "needed",
+};
+// To:
+const newState: PermissionsState = {
+  accessibility: "needed",
+  microphone: "needed",
+};
+```
+
+## Revert
+
+Undo all three changes when done testing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+Handless is a macOS desktop speech-to-text app built with Tauri 2.x (Rust backend + React/TypeScript frontend).
+
+## Design Context
+
+### Users
+
+Developers, power users, and general productivity users who want fast, accurate speech-to-text on desktop. They reach for Handless to dictate text instead of typing — notes, emails, messages, code comments. The app should feel like a native utility, not a complex tool requiring configuration.
+
+### Brand Personality
+
+**Calm, elegant, refined.** A premium desktop utility that feels thoughtfully crafted. Not flashy or attention-seeking — confident and understated, like a well-made instrument.
+
+### Emotional Goals
+
+- **Confidence & trust** — "My words are captured accurately"
+- **Calm focus** — "It stays out of my way and lets me think"
+- **Delight & craft** — "This feels really well-made"
+- **Speed & efficiency** — "Everything feels instant"
+
+### Aesthetic Direction
+
+- **Reference:** Raycast — minimal, fast utility app with clean glass UI that stays out of the way
+- **Anti-references:** Electron apps (Slack/Discord heaviness), generic SaaS dashboards, skeuomorphic decoration
+- **Theme:** Dark-first with warm glass morphism. Orange accent (#ef6f2f) with warm neutrals
+- **Typography:** Geist — modern, clean, highly legible
+- **Motion:** Spring-based micro-interactions that feel responsive, never decorative
+
+### Design Principles
+
+1. **Invisible until needed** — The app should disappear into the user's workflow. Minimal chrome, no unnecessary UI. Like Raycast: summon it, use it, move on.
+2. **Warmth over sterility** — Warm browns and orange accent prevent the glass aesthetic from feeling cold or clinical. The palette should feel inviting.
+3. **Motion with purpose** — Every animation communicates state change (recording, processing, complete). No gratuitous animation. Spring physics for natural feel.
+4. **Native-quality craft** — Should feel like a macOS-native app, not a web app in a wrapper. Tight spacing, precise typography, glass effects that match system vibrancy.
+5. **Clarity over density** — Prefer generous whitespace and clear hierarchy. Settings and options should be discoverable but never overwhelming.
+
+## Development
+
+### Commands
+
+```bash
+bun run tauri dev                # Dev mode (prefix CMAKE_POLICY_VERSION_MINIMUM=3.5 if cmake errors on macOS)
+bun run tauri build              # Production build
+bun run lint                     # ESLint check
+bun run lint:fix                 # ESLint auto-fix
+bun run format                   # Prettier + cargo fmt
+bun run format:check             # Check formatting only
+bun run test:playwright          # E2E tests
+bun run check:translations       # Validate translation files
+```
+
+### Code Style
+
+**Rust:**
+
+- `cargo fmt` + `cargo clippy` before committing
+- Explicit error handling (avoid `unwrap` in production)
+- New Tauri commands in `commands/`, business logic in `managers/`
+- Use specta for type-safe command bindings (auto-generates `bindings.ts`)
+
+**TypeScript/React:**
+
+- Strict TypeScript, no `any`
+- Functional components with hooks
+- Tailwind CSS for styling, Radix UI for primitives
+- Icons: `@phosphor-icons/react` — use Phosphor icons instead of inline SVGs
+- Path alias: `@/` → `./src/`
+- State: Zustand stores in `stores/`
+- New settings components go in the appropriate `settings/` subdirectory
+
+### i18n
+
+All user-facing strings use i18next (ESLint enforces no hardcoded JSX strings).
+
+**During development:**
+
+1. Add key to `src/i18n/locales/en/translation.json` only
+2. Use in component: `const { t } = useTranslation(); t('key.path')`
+
+**Before committing:**
+
+3. Add the same key to all 16 other locale files (ar, cs, de, es, fr, it, ja, ko, pl, pt, ru, tr, uk, vi, zh, zh-TW) — use English as placeholder
+4. Run `bun run check:translations` to verify all locales have matching keys
+
+Keys are organized by feature area: `tray.*`, `sidebar.*`, `onboarding.*`, `settings.*`, `models.*`, etc.
+
+### Cloud STT Testing
+
+Integration tests for cloud STT providers live in `src-tauri/tests/cloud_stt.rs`, gated behind the `cloud-stt-tests` cargo feature. When changing a cloud provider's default model name or base URL in `src-tauri/src/stt_provider.rs`, also update the corresponding constants in `src-tauri/tests/cloud_stt.rs` so tests run against the correct model.
+
+```bash
+cargo test --features cloud-stt-tests --test cloud_stt              # All providers
+cargo test --features cloud-stt-tests --test cloud_stt -- openai    # Single provider
+cargo test --features cloud-stt-tests --test cloud_stt -- realtime  # Only realtime tests
+```
+
+API keys are loaded from `.env` at the repo root (gitignored). Tests skip gracefully if a provider's key is missing.

--- a/src-tauri/src/cloud_stt/doubao.rs
+++ b/src-tauri/src/cloud_stt/doubao.rs
@@ -13,8 +13,7 @@ use tokio_tungstenite::{
 
 // ─── Default endpoint ───────────────────────────────────────────────
 
-pub(crate) const DEFAULT_WS_URL: &str =
-    "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async";
+pub(crate) const DEFAULT_WS_URL: &str = "wss://openspeech.bytedance.com/api/v3/sauc/bigmodel_async";
 const DEFAULT_RESOURCE_ID: &str = "volc.seedasr.sauc.duration";
 
 // ─── Binary protocol constants ──────────────────────────────────────
@@ -108,12 +107,7 @@ fn map_language_code(lang: &str) -> &str {
 
 // ─── Binary protocol helpers ────────────────────────────────────────
 
-pub(crate) fn build_header(
-    msg_type: u8,
-    flags: u8,
-    serialization: u8,
-    compression: u8,
-) -> [u8; 4] {
+pub(crate) fn build_header(msg_type: u8, flags: u8, serialization: u8, compression: u8) -> [u8; 4] {
     [
         (PROTOCOL_VERSION << 4) | HEADER_SIZE,
         (msg_type << 4) | flags,

--- a/src-tauri/src/cloud_stt/realtime/deepgram.rs
+++ b/src-tauri/src/cloud_stt/realtime/deepgram.rs
@@ -17,8 +17,7 @@ fn build_ws_url(model: &str, encoding: &str, options: Option<&serde_json::Value>
         .and_then(|o| o.get("language"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty());
-    let effective_model =
-        crate::cloud_stt::deepgram::resolve_model_for_language(model, lang);
+    let effective_model = crate::cloud_stt::deepgram::resolve_model_for_language(model, lang);
 
     let mut params = vec![
         ("model".to_string(), effective_model.to_string()),

--- a/src-tauri/src/cloud_stt/realtime/doubao.rs
+++ b/src-tauri/src/cloud_stt/realtime/doubao.rs
@@ -43,8 +43,7 @@ pub async fn start_streaming(
     options: Option<serde_json::Value>,
     delta_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
 ) -> Result<StreamingHandles> {
-    let (access_key, app_key, resource_id) =
-        extract_credentials(api_key, options.as_ref())?;
+    let (access_key, app_key, resource_id) = extract_credentials(api_key, options.as_ref())?;
 
     let request = build_ws_request(DEFAULT_WS_URL, access_key, app_key, resource_id)?;
 
@@ -142,9 +141,7 @@ pub async fn start_streaming(
                         break;
                     }
                     DoubaoEvent::Error { code, message } => {
-                        return Err(anyhow::anyhow!(
-                            "Doubao server error {code}: {message}"
-                        ));
+                        return Err(anyhow::anyhow!("Doubao server error {code}: {message}"));
                     }
                 }
             } else if let Message::Close(_) = msg {

--- a/src-tauri/src/commands/data_transfer.rs
+++ b/src-tauri/src/commands/data_transfer.rs
@@ -1,16 +1,18 @@
 use crate::managers::history::{DailySpeakingStats, HistoryEntry, HistoryManager};
-use crate::settings::{get_settings, write_settings, AppSettings};
+use crate::settings::{get_settings, load_or_create_app_settings, persisted_settings_value};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use specta::Type;
 use std::fs;
 use std::io::{self, Read as _};
 use std::sync::Arc;
 use tar::{Archive, Builder as TarBuilder};
 use tauri::{AppHandle, State};
+use tauri_plugin_store::StoreExt;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Type)]
 pub struct ExportManifest {
@@ -25,7 +27,7 @@ pub struct ExportManifest {
 struct ExportData {
     manifest: ExportManifest,
     #[serde(default)]
-    settings: Option<AppSettings>,
+    settings: Option<JsonValue>,
     #[serde(default)]
     history: Vec<HistoryEntry>,
     #[serde(default)]
@@ -129,7 +131,7 @@ pub async fn export_app_data(
     );
 
     let settings = if include_settings {
-        Some(get_settings(&app))
+        Some(get_settings(&app)).map(|settings| persisted_settings_value(&settings))
     } else {
         None
     };
@@ -390,9 +392,12 @@ fn import_from_tar_gz(
     Ok(())
 }
 
-fn apply_imported_settings(app: &AppHandle, settings: AppSettings) -> Result<(), String> {
-    write_settings(app, settings);
-    crate::settings::load_or_create_app_settings(app);
+fn apply_imported_settings(app: &AppHandle, settings: JsonValue) -> Result<(), String> {
+    let store = app
+        .store(crate::settings::SETTINGS_STORE_PATH)
+        .map_err(|e| format!("Failed to access settings store: {}", e))?;
+    store.set("settings", settings);
+    load_or_create_app_settings(app);
     info!("Settings imported and migrations applied");
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,6 @@
 pub(crate) mod actions;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod apple_intelligence;
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-pub(crate) mod notch;
 mod audio_feedback;
 pub mod audio_toolkit;
 pub mod cli;
@@ -13,6 +11,8 @@ mod device_watcher;
 mod helpers;
 mod input;
 mod managers;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub(crate) mod notch;
 mod overlay;
 pub mod post_process;
 mod settings;

--- a/src-tauri/src/post_process/prompts.rs
+++ b/src-tauri/src/post_process/prompts.rs
@@ -1,9 +1,8 @@
 use crate::settings::AppSettings;
-use log::debug;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Type)]
 pub struct LLMPrompt {
     pub id: String,
     pub name: String,
@@ -14,6 +13,7 @@ pub const BUILTIN_PROMPT_PREFIX: &str = "default_";
 pub const BUILTIN_PROMPT_CORRECT: &str = "default_correct";
 const BUILTIN_PROMPT_IMPROVE: &str = "default_improve";
 const BUILTIN_PROMPT_RESTRUCTURE: &str = "default_restructure";
+const LEGACY_BUILTIN_PROMPT_IMPROVE_TRANSCRIPTIONS: &str = "default_improve_transcriptions";
 
 pub fn is_builtin_prompt(id: &str) -> bool {
     id.starts_with(BUILTIN_PROMPT_PREFIX)
@@ -43,48 +43,99 @@ pub fn default_selected_prompt_id() -> Option<String> {
     Some(BUILTIN_PROMPT_CORRECT.to_string())
 }
 
-pub fn ensure_prompt_defaults(settings: &mut AppSettings) -> bool {
-    let mut changed = false;
+pub fn normalized_prompts(stored_prompts: &[LLMPrompt]) -> Vec<LLMPrompt> {
+    let mut prompts = default_prompts();
 
-    // Sync built-in prompts: add missing ones and update content/name for existing ones
-    let builtin_prompts = default_prompts();
-    for default_prompt in &builtin_prompts {
-        match settings
-            .post_process_prompts
-            .iter_mut()
-            .find(|p| p.id == default_prompt.id)
-        {
-            Some(existing) => {
-                if existing.prompt != default_prompt.prompt || existing.name != default_prompt.name
-                {
-                    existing.prompt = default_prompt.prompt.clone();
-                    existing.name = default_prompt.name.clone();
-                    changed = true;
-                }
-            }
-            None => {
-                debug!("Adding missing default prompt: {}", default_prompt.id);
-                settings.post_process_prompts.push(default_prompt.clone());
+    for prompt in stored_prompts {
+        if is_builtin_prompt(&prompt.id) {
+            continue;
+        }
+
+        prompts.push(prompt.clone());
+    }
+
+    prompts
+}
+
+fn remap_prompt_reference(prompt_id: &str) -> Option<String> {
+    match prompt_id {
+        LEGACY_BUILTIN_PROMPT_IMPROVE_TRANSCRIPTIONS => Some(BUILTIN_PROMPT_CORRECT.to_string()),
+        _ => None,
+    }
+}
+
+pub fn ensure_prompt_defaults(settings: &mut AppSettings) -> bool {
+    let normalized_prompts = normalized_prompts(&settings.post_process_prompts);
+    let mut changed = settings.post_process_prompts != normalized_prompts;
+
+    if changed {
+        settings.post_process_prompts = normalized_prompts;
+    }
+
+    if let Some(selected_prompt_id) = settings.post_process_selected_prompt_id.clone() {
+        if let Some(remapped_prompt_id) = remap_prompt_reference(&selected_prompt_id) {
+            if settings.post_process_selected_prompt_id != Some(remapped_prompt_id.clone()) {
+                settings.post_process_selected_prompt_id = Some(remapped_prompt_id);
                 changed = true;
             }
         }
     }
 
-    // Migrate from old default_improve_transcriptions prompt
-    if let Some(old_idx) = settings
-        .post_process_prompts
-        .iter()
-        .position(|p| p.id == "default_improve_transcriptions")
-    {
-        // If the user had the old default selected, switch to the new default
-        if settings.post_process_selected_prompt_id.as_deref()
-            == Some("default_improve_transcriptions")
-        {
-            settings.post_process_selected_prompt_id = Some(BUILTIN_PROMPT_CORRECT.to_string());
+    for binding in settings.bindings.values_mut() {
+        let Some(prompt_id) = binding.post_process_prompt_id.clone() else {
+            continue;
+        };
+
+        if let Some(remapped_prompt_id) = remap_prompt_reference(&prompt_id) {
+            if binding.post_process_prompt_id != Some(remapped_prompt_id.clone()) {
+                binding.post_process_prompt_id = Some(remapped_prompt_id);
+                changed = true;
+            }
         }
-        settings.post_process_prompts.remove(old_idx);
-        changed = true;
     }
 
     changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_prompts_keep_stable_builtin_ids() {
+        let ids = default_prompts()
+            .into_iter()
+            .map(|prompt| prompt.id)
+            .collect::<Vec<_>>();
+
+        assert!(ids.iter().any(|id| id == "default_correct"));
+        assert!(ids.iter().any(|id| id == "default_improve"));
+        assert!(ids.iter().any(|id| id == "default_restructure"));
+    }
+
+    #[test]
+    fn ensure_prompt_defaults_remaps_legacy_builtin_prompt_references() {
+        let mut settings = crate::settings::get_default_settings();
+        settings.post_process_selected_prompt_id =
+            Some(LEGACY_BUILTIN_PROMPT_IMPROVE_TRANSCRIPTIONS.to_string());
+        settings
+            .bindings
+            .get_mut("transcribe_with_post_process")
+            .expect("binding should exist")
+            .post_process_prompt_id =
+            Some(LEGACY_BUILTIN_PROMPT_IMPROVE_TRANSCRIPTIONS.to_string());
+
+        assert!(ensure_prompt_defaults(&mut settings));
+        assert_eq!(
+            settings.post_process_selected_prompt_id,
+            Some(BUILTIN_PROMPT_CORRECT.to_string())
+        );
+        assert_eq!(
+            settings
+                .bindings
+                .get("transcribe_with_post_process")
+                .and_then(|binding| binding.post_process_prompt_id.clone()),
+            Some(BUILTIN_PROMPT_CORRECT.to_string())
+        );
+    }
 }

--- a/src-tauri/src/post_process/providers.rs
+++ b/src-tauri/src/post_process/providers.rs
@@ -5,7 +5,7 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Type)]
 pub struct PostProcessProvider {
     pub id: String,
     pub label: String,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,9 +1,12 @@
 use log::{debug, warn};
-use serde::de::{self, Visitor};
+use serde::de::{self, DeserializeOwned, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 use specta::Type;
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use tauri::AppHandle;
+use tauri::Manager;
 use tauri_plugin_store::StoreExt;
 
 #[derive(Serialize, Default, Debug, Clone, Copy, PartialEq, Eq, Type)]
@@ -15,10 +18,6 @@ pub enum ActivationMode {
     HoldOrToggle,
 }
 
-// TODO: Remove this custom Deserialize impl once all users have migrated from
-// the old push_to_talk boolean setting (added 2026-03-12). After removal,
-// derive Deserialize normally and also remove the `alias = "push_to_talk"`
-// on AppSettings.activation_mode.
 impl<'de> Deserialize<'de> for ActivationMode {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -46,7 +45,6 @@ impl<'de> Deserialize<'de> for ActivationMode {
             }
 
             fn visit_bool<E: de::Error>(self, value: bool) -> Result<ActivationMode, E> {
-                // Migrate old push_to_talk boolean: true → Hold, false → Toggle
                 Ok(if value {
                     ActivationMode::Hold
                 } else {
@@ -132,18 +130,22 @@ impl From<LogLevel> for tauri_plugin_log::LogLevel {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Type)]
 pub struct ShortcutBinding {
     pub id: String,
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub description: String,
+    #[serde(default)]
     pub default_binding: String,
+    #[serde(default)]
     pub current_binding: String,
     #[serde(default)]
     pub post_process_prompt_id: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Type)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Type)]
 pub struct SttProvider {
     pub id: String,
     pub label: String,
@@ -322,9 +324,9 @@ pub enum TypingTool {
 /* still useful for composing the initial JSON in the store ------------- */
 #[derive(Serialize, Deserialize, Debug, Clone, Type)]
 pub struct AppSettings {
+    #[serde(default = "default_bindings")]
     pub bindings: HashMap<String, ShortcutBinding>,
     #[serde(default, alias = "push_to_talk")]
-    // TODO: remove alias after migration period (see ActivationMode Deserialize impl)
     pub activation_mode: ActivationMode,
     #[serde(default = "default_audio_feedback_volume")]
     pub audio_feedback_volume: f32,
@@ -556,6 +558,64 @@ fn default_post_process_selected_prompt_id() -> Option<String> {
     crate::post_process::prompts::default_selected_prompt_id()
 }
 
+fn default_bindings() -> HashMap<String, ShortcutBinding> {
+    #[cfg(target_os = "windows")]
+    let default_shortcut = "ctrl+space";
+    #[cfg(target_os = "macos")]
+    let default_shortcut = "fn";
+    #[cfg(target_os = "linux")]
+    let default_shortcut = "ctrl+space";
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    let default_shortcut = "alt+space";
+
+    let mut bindings = HashMap::new();
+    bindings.insert(
+        "transcribe".to_string(),
+        ShortcutBinding {
+            id: "transcribe".to_string(),
+            name: "Transcribe".to_string(),
+            description: "Converts your speech into text.".to_string(),
+            default_binding: default_shortcut.to_string(),
+            current_binding: default_shortcut.to_string(),
+            post_process_prompt_id: None,
+        },
+    );
+    #[cfg(target_os = "windows")]
+    let default_post_process_shortcut = "ctrl+shift+space";
+    #[cfg(target_os = "macos")]
+    let default_post_process_shortcut = "option+shift+space";
+    #[cfg(target_os = "linux")]
+    let default_post_process_shortcut = "ctrl+shift+space";
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    let default_post_process_shortcut = "alt+shift+space";
+
+    bindings.insert(
+        "transcribe_with_post_process".to_string(),
+        ShortcutBinding {
+            id: "transcribe_with_post_process".to_string(),
+            name: "Transcribe with Post-Processing".to_string(),
+            description: "Converts your speech into text and applies AI post-processing."
+                .to_string(),
+            default_binding: default_post_process_shortcut.to_string(),
+            current_binding: default_post_process_shortcut.to_string(),
+            post_process_prompt_id: None,
+        },
+    );
+    bindings.insert(
+        "cancel".to_string(),
+        ShortcutBinding {
+            id: "cancel".to_string(),
+            name: "Cancel".to_string(),
+            description: "Cancels the current recording.".to_string(),
+            default_binding: "escape".to_string(),
+            current_binding: "escape".to_string(),
+            post_process_prompt_id: None,
+        },
+    );
+
+    bindings
+}
+
 fn default_typing_tool() -> TypingTool {
     TypingTool::Auto
 }
@@ -753,63 +813,501 @@ fn ensure_post_process_defaults(settings: &mut AppSettings) -> bool {
 
 pub const SETTINGS_STORE_PATH: &str = "settings_store.json";
 
+fn configured_provider_ids(values: &HashMap<String, String>) -> Vec<String> {
+    let mut providers = values
+        .iter()
+        .filter_map(|(provider_id, value)| {
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(provider_id.clone())
+            }
+        })
+        .collect::<Vec<_>>();
+    providers.sort();
+    providers
+}
+
+fn is_builtin_binding_id(binding_id: &str) -> bool {
+    default_bindings().contains_key(binding_id)
+}
+
+fn normalized_bindings(
+    stored_bindings: &HashMap<String, ShortcutBinding>,
+) -> HashMap<String, ShortcutBinding> {
+    let mut bindings = default_bindings();
+
+    for (binding_id, stored_binding) in stored_bindings {
+        if let Some(default_binding) = bindings.get_mut(binding_id) {
+            if !stored_binding.current_binding.is_empty() {
+                default_binding.current_binding = stored_binding.current_binding.clone();
+            }
+            default_binding.post_process_prompt_id = stored_binding.post_process_prompt_id.clone();
+            continue;
+        }
+
+        let mut custom_binding = stored_binding.clone();
+        if custom_binding.current_binding.is_empty() {
+            custom_binding.current_binding = custom_binding.default_binding.clone();
+        }
+        if custom_binding.default_binding.is_empty() {
+            custom_binding.default_binding = custom_binding.current_binding.clone();
+        }
+
+        bindings.insert(binding_id.clone(), custom_binding);
+    }
+
+    bindings
+}
+
+fn read_json_field<T: DeserializeOwned>(
+    object: &JsonMap<String, JsonValue>,
+    key: &str,
+) -> Option<T> {
+    object
+        .get(key)
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+}
+
+fn recover_custom_post_process_base_url(value: &JsonValue) -> Option<String> {
+    value.as_array().and_then(|providers| {
+        providers.iter().find_map(|provider| {
+            let object = provider.as_object()?;
+            let provider_id = object.get("id")?.as_str()?;
+            if provider_id != "custom" {
+                return None;
+            }
+            object
+                .get("base_url")
+                .and_then(|base_url| base_url.as_str())
+                .map(str::to_string)
+        })
+    })
+}
+
+fn configured_custom_post_process_base_url(object: &JsonMap<String, JsonValue>) -> Option<String> {
+    read_json_field::<String>(object, "post_process_custom_base_url").or_else(|| {
+        object
+            .get("post_process_providers")
+            .and_then(recover_custom_post_process_base_url)
+    })
+}
+
+fn apply_custom_post_process_base_url(
+    settings: &mut AppSettings,
+    custom_base_url: Option<String>,
+) -> bool {
+    let Some(custom_base_url) = custom_base_url else {
+        return false;
+    };
+
+    let Some(custom_provider) = settings
+        .post_process_providers
+        .iter_mut()
+        .find(|provider| provider.id == "custom")
+    else {
+        return false;
+    };
+
+    if custom_provider.base_url == custom_base_url {
+        return false;
+    }
+
+    custom_provider.base_url = custom_base_url;
+    true
+}
+
+fn normalized_post_process_providers(
+    stored_providers: &[PostProcessProvider],
+) -> Vec<PostProcessProvider> {
+    let custom_base_url = stored_providers
+        .iter()
+        .find(|provider| provider.id == "custom")
+        .map(|provider| provider.base_url.clone());
+
+    let mut providers = default_post_process_providers();
+    if let Some(custom_base_url) = custom_base_url {
+        if let Some(custom_provider) = providers
+            .iter_mut()
+            .find(|provider| provider.id == "custom")
+        {
+            custom_provider.base_url = custom_base_url;
+        }
+    }
+
+    providers
+}
+
+fn custom_post_process_base_url(settings: &AppSettings) -> Option<String> {
+    settings
+        .post_process_provider("custom")
+        .map(|provider| provider.base_url.clone())
+}
+
+fn persisted_settings_requires_rewrite(settings_value: &JsonValue) -> bool {
+    let Some(object) = settings_value.as_object() else {
+        return false;
+    };
+
+    object.contains_key("stt_providers")
+        || object.contains_key("post_process_providers")
+        || object
+            .get("post_process_prompts")
+            .and_then(JsonValue::as_array)
+            .is_some_and(|prompts| {
+                prompts.iter().any(|prompt| {
+                    prompt
+                        .as_object()
+                        .and_then(|prompt| prompt.get("id"))
+                        .and_then(JsonValue::as_str)
+                        .is_some_and(crate::post_process::is_builtin_prompt)
+                })
+            })
+        || object
+            .get("bindings")
+            .and_then(JsonValue::as_object)
+            .is_some_and(|bindings| {
+                bindings.iter().any(|(binding_id, binding)| {
+                    is_builtin_binding_id(binding_id)
+                        && binding.as_object().is_some_and(|binding| {
+                            binding.contains_key("name")
+                                || binding.contains_key("description")
+                                || binding.contains_key("default_binding")
+                        })
+                })
+            })
+}
+
+fn persisted_bindings_value(settings: &AppSettings) -> JsonValue {
+    let default_bindings = default_bindings();
+    let bindings = settings
+        .bindings
+        .iter()
+        .filter_map(|(binding_id, binding)| {
+            if let Some(default_binding) = default_bindings.get(binding_id) {
+                let has_override = binding.current_binding != default_binding.current_binding
+                    || binding.post_process_prompt_id != default_binding.post_process_prompt_id;
+                if !has_override {
+                    return None;
+                }
+
+                return Some((
+                    binding_id.clone(),
+                    serde_json::json!({
+                        "id": binding.id,
+                        "current_binding": binding.current_binding,
+                        "post_process_prompt_id": binding.post_process_prompt_id,
+                    }),
+                ));
+            }
+
+            Some((
+                binding_id.clone(),
+                serde_json::to_value(binding).expect("Failed to serialize shortcut binding"),
+            ))
+        })
+        .collect::<JsonMap<String, JsonValue>>();
+
+    JsonValue::Object(bindings)
+}
+
+fn persisted_post_process_prompts_value(settings: &AppSettings) -> JsonValue {
+    JsonValue::Array(
+        settings
+            .post_process_prompts
+            .iter()
+            .filter(|prompt| !crate::post_process::is_builtin_prompt(&prompt.id))
+            .map(|prompt| serde_json::to_value(prompt).expect("Failed to serialize prompt"))
+            .collect(),
+    )
+}
+
+pub(crate) fn persisted_settings_value(settings: &AppSettings) -> JsonValue {
+    let mut value = serde_json::to_value(settings).expect("Failed to serialize settings");
+    let JsonValue::Object(object) = &mut value else {
+        unreachable!("AppSettings must serialize to a JSON object");
+    };
+
+    object.remove("stt_providers");
+    object.remove("post_process_providers");
+    object.insert("bindings".to_string(), persisted_bindings_value(settings));
+    object.insert(
+        "post_process_prompts".to_string(),
+        persisted_post_process_prompts_value(settings),
+    );
+
+    if let Some(custom_base_url) = custom_post_process_base_url(settings) {
+        object.insert(
+            "post_process_custom_base_url".to_string(),
+            JsonValue::String(custom_base_url),
+        );
+    }
+
+    value
+}
+
+fn normalize_provider_catalogs(settings: &mut AppSettings) -> bool {
+    let mut changed = false;
+
+    let current_stt_providers = default_stt_providers();
+    if settings.stt_providers != current_stt_providers {
+        settings.stt_providers = current_stt_providers;
+        changed = true;
+    }
+
+    let current_post_process_providers =
+        normalized_post_process_providers(&settings.post_process_providers);
+    if settings.post_process_providers != current_post_process_providers {
+        settings.post_process_providers = current_post_process_providers;
+        changed = true;
+    }
+
+    changed
+}
+
+fn normalize_settings_definitions(settings: &mut AppSettings) -> bool {
+    let mut changed = false;
+
+    let current_bindings = normalized_bindings(&settings.bindings);
+    if settings.bindings != current_bindings {
+        settings.bindings = current_bindings;
+        changed = true;
+    }
+
+    let current_prompts =
+        crate::post_process::prompts::normalized_prompts(&settings.post_process_prompts);
+    if settings.post_process_prompts != current_prompts {
+        settings.post_process_prompts = current_prompts;
+        changed = true;
+    }
+
+    changed
+}
+
+fn recover_settings_from_value(settings_value: JsonValue) -> AppSettings {
+    let mut settings = get_default_settings();
+    let Some(object) = settings_value.as_object() else {
+        return settings;
+    };
+
+    if let Some(value) = read_json_field(object, "activation_mode")
+        .or_else(|| read_json_field(object, "push_to_talk"))
+    {
+        settings.activation_mode = value;
+    }
+
+    macro_rules! recover_field {
+        ($field:ident) => {
+            if let Some(value) = read_json_field(object, stringify!($field)) {
+                settings.$field = value;
+            }
+        };
+    }
+
+    recover_field!(bindings);
+    recover_field!(audio_feedback_volume);
+    recover_field!(sound_theme);
+    recover_field!(start_hidden);
+    recover_field!(autostart_enabled);
+    recover_field!(update_checks_enabled);
+    recover_field!(selected_model);
+    recover_field!(always_on_microphone);
+    recover_field!(selected_microphone);
+    recover_field!(microphone_priority);
+    recover_field!(clamshell_microphone);
+    recover_field!(selected_output_device);
+    recover_field!(translate_to_english);
+    recover_field!(selected_language);
+    recover_field!(overlay_position);
+    recover_field!(debug_mode);
+    recover_field!(log_level);
+    recover_field!(custom_words);
+    recover_field!(model_unload_timeout);
+    recover_field!(word_correction_threshold);
+    recover_field!(history_limit);
+    recover_field!(recording_retention_period);
+    recover_field!(paste_method);
+    recover_field!(clipboard_handling);
+    recover_field!(auto_submit);
+    recover_field!(auto_submit_key);
+    recover_field!(stt_provider_id);
+    recover_field!(stt_api_keys);
+    recover_field!(stt_cloud_models);
+    recover_field!(post_process_enabled);
+    recover_field!(post_process_provider_id);
+    recover_field!(post_process_api_keys);
+    recover_field!(post_process_models);
+    recover_field!(post_process_prompts);
+    recover_field!(post_process_selected_prompt_id);
+    recover_field!(mute_while_recording);
+    recover_field!(append_trailing_space);
+    recover_field!(app_language);
+    recover_field!(keyboard_implementation);
+    recover_field!(show_tray_icon);
+    recover_field!(paste_delay_ms);
+    recover_field!(typing_tool);
+    recover_field!(external_script_path);
+    recover_field!(app_theme);
+    recover_field!(stt_verified_providers);
+    recover_field!(post_process_verified_providers);
+    recover_field!(post_process_input_prices);
+    recover_field!(post_process_output_prices);
+    recover_field!(stt_cloud_options);
+    recover_field!(stt_realtime_enabled);
+    recover_field!(stats_date_range);
+    recover_field!(dictionary_terms);
+    recover_field!(dictionary_context);
+
+    if let Some(stored_providers) =
+        read_json_field::<Vec<PostProcessProvider>>(object, "post_process_providers")
+    {
+        settings.post_process_providers = normalized_post_process_providers(&stored_providers);
+    }
+
+    apply_custom_post_process_base_url(
+        &mut settings,
+        configured_custom_post_process_base_url(object),
+    );
+
+    settings
+}
+
+fn backup_invalid_settings_store(app: &AppHandle) {
+    let Ok(app_data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+
+    let store_path = app_data_dir.join(SETTINGS_STORE_PATH);
+    if !store_path.exists() {
+        return;
+    }
+
+    let backup_path = app_data_dir.join(format!(
+        "settings_store.invalid-{}.json",
+        chrono::Local::now().format("%Y%m%d-%H%M%S")
+    ));
+
+    match fs::copy(&store_path, &backup_path) {
+        Ok(_) => warn!(
+            "Backed up invalid settings store to {}",
+            backup_path.display()
+        ),
+        Err(error) => warn!(
+            "Failed to back up invalid settings store to {}: {}",
+            backup_path.display(),
+            error
+        ),
+    }
+}
+
+fn apply_settings_migrations(settings: &mut AppSettings) -> bool {
+    let mut updated = normalize_provider_catalogs(settings);
+    updated |= normalize_settings_definitions(settings);
+
+    if settings.microphone_priority.is_empty() {
+        if let Some(ref mic) = settings.selected_microphone {
+            debug!(
+                "Migrating selected_microphone '{}' to microphone_priority",
+                mic
+            );
+            settings.microphone_priority = vec![mic.clone()];
+            updated = true;
+        }
+    }
+
+    if let Some(binding) = settings.bindings.get_mut("transcribe_with_post_process") {
+        if binding.post_process_prompt_id.is_none() {
+            let prompt_id = settings
+                .post_process_selected_prompt_id
+                .clone()
+                .unwrap_or_else(|| crate::post_process::BUILTIN_PROMPT_CORRECT.to_string());
+            debug!(
+                "Migrating transcribe_with_post_process prompt_id to '{}'",
+                prompt_id
+            );
+            binding.post_process_prompt_id = Some(prompt_id);
+            updated = true;
+        }
+    }
+
+    if settings.stt_provider(&settings.stt_provider_id).is_none() {
+        settings.stt_provider_id = default_stt_provider_id();
+        updated = true;
+    }
+
+    if settings
+        .post_process_provider(&settings.post_process_provider_id)
+        .is_none()
+    {
+        settings.post_process_provider_id = default_post_process_provider_id();
+        updated = true;
+    }
+
+    updated |= ensure_stt_defaults(settings);
+    updated |= ensure_post_process_defaults(settings);
+
+    updated
+}
+
+fn read_or_create_app_settings(app: &AppHandle, log_existing: bool) -> AppSettings {
+    let store = app
+        .store(SETTINGS_STORE_PATH)
+        .expect("Failed to initialize store");
+
+    let (mut settings, mut updated) = if let Some(settings_value) = store.get("settings") {
+        match serde_json::from_value::<AppSettings>(settings_value.clone()) {
+            Ok(mut settings) => {
+                let settings_updated = settings_value.as_object().is_some_and(|object| {
+                    apply_custom_post_process_base_url(
+                        &mut settings,
+                        configured_custom_post_process_base_url(object),
+                    )
+                });
+                if log_existing {
+                    debug!(
+                        "Found existing settings: selected_model={}, stt_provider_id={}, post_process_provider_id={}, bindings={:?}, microphone_priority={:?}, clipboard_handling={:?}, mute_while_recording={}, app_language={}, stats_date_range={:?}, configured_stt_api_keys={:?}, configured_post_process_api_keys={:?}",
+                        settings.selected_model,
+                        settings.stt_provider_id,
+                        settings.post_process_provider_id,
+                        settings.bindings,
+                        settings.microphone_priority,
+                        settings.clipboard_handling,
+                        settings.mute_while_recording,
+                        settings.app_language,
+                        settings.stats_date_range,
+                        configured_provider_ids(&settings.stt_api_keys),
+                        configured_provider_ids(&settings.post_process_api_keys),
+                    );
+                }
+                (
+                    settings,
+                    persisted_settings_requires_rewrite(&settings_value) || settings_updated,
+                )
+            }
+            Err(error) => {
+                warn!("Failed to parse settings: {}", error);
+                backup_invalid_settings_store(app);
+                let recovered = recover_settings_from_value(settings_value);
+                warn!("Recovered settings from partially invalid configuration data");
+                (recovered, true)
+            }
+        }
+    } else {
+        (get_default_settings(), true)
+    };
+
+    updated |= apply_settings_migrations(&mut settings);
+
+    if updated {
+        store.set("settings", persisted_settings_value(&settings));
+    }
+
+    settings
+}
+
 pub fn get_default_settings() -> AppSettings {
-    #[cfg(target_os = "windows")]
-    let default_shortcut = "ctrl+space";
-    #[cfg(target_os = "macos")]
-    let default_shortcut = "fn";
-    #[cfg(target_os = "linux")]
-    let default_shortcut = "ctrl+space";
-    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    let default_shortcut = "alt+space";
-
-    let mut bindings = HashMap::new();
-    bindings.insert(
-        "transcribe".to_string(),
-        ShortcutBinding {
-            id: "transcribe".to_string(),
-            name: "Transcribe".to_string(),
-            description: "Converts your speech into text.".to_string(),
-            default_binding: default_shortcut.to_string(),
-            current_binding: default_shortcut.to_string(),
-            post_process_prompt_id: None,
-        },
-    );
-    #[cfg(target_os = "windows")]
-    let default_post_process_shortcut = "ctrl+shift+space";
-    #[cfg(target_os = "macos")]
-    let default_post_process_shortcut = "option+shift+space";
-    #[cfg(target_os = "linux")]
-    let default_post_process_shortcut = "ctrl+shift+space";
-    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    let default_post_process_shortcut = "alt+shift+space";
-
-    bindings.insert(
-        "transcribe_with_post_process".to_string(),
-        ShortcutBinding {
-            id: "transcribe_with_post_process".to_string(),
-            name: "Transcribe with Post-Processing".to_string(),
-            description: "Converts your speech into text and applies AI post-processing."
-                .to_string(),
-            default_binding: default_post_process_shortcut.to_string(),
-            current_binding: default_post_process_shortcut.to_string(),
-            post_process_prompt_id: None,
-        },
-    );
-    bindings.insert(
-        "cancel".to_string(),
-        ShortcutBinding {
-            id: "cancel".to_string(),
-            name: "Cancel".to_string(),
-            description: "Cancels the current recording.".to_string(),
-            default_binding: "escape".to_string(),
-            current_binding: "escape".to_string(),
-            post_process_prompt_id: None,
-        },
-    );
-
     AppSettings {
-        bindings,
+        bindings: default_bindings(),
         activation_mode: ActivationMode::HoldOrToggle,
         audio_feedback_volume: default_audio_feedback_volume(),
         sound_theme: default_sound_theme(),
@@ -898,89 +1396,7 @@ impl AppSettings {
 }
 
 pub fn load_or_create_app_settings(app: &AppHandle) -> AppSettings {
-    // Initialize store
-    let store = app
-        .store(SETTINGS_STORE_PATH)
-        .expect("Failed to initialize store");
-
-    let mut settings = if let Some(settings_value) = store.get("settings") {
-        // Parse the entire settings object
-        match serde_json::from_value::<AppSettings>(settings_value) {
-            Ok(mut settings) => {
-                debug!("Found existing settings: {:?}", settings);
-                let default_settings = get_default_settings();
-                let mut updated = false;
-
-                // Merge default bindings into existing settings
-                for (key, value) in default_settings.bindings {
-                    if let std::collections::hash_map::Entry::Vacant(e) =
-                        settings.bindings.entry(key)
-                    {
-                        debug!("Adding missing binding: {}", e.key());
-                        e.insert(value);
-                        updated = true;
-                    }
-                }
-
-                // Migrate: populate microphone_priority from selected_microphone
-                if settings.microphone_priority.is_empty() {
-                    if let Some(ref mic) = settings.selected_microphone {
-                        debug!(
-                            "Migrating selected_microphone '{}' to microphone_priority",
-                            mic
-                        );
-                        settings.microphone_priority = vec![mic.clone()];
-                        updated = true;
-                    }
-                }
-
-                // Migrate: populate post_process_prompt_id for existing
-                // transcribe_with_post_process binding from the global setting
-                if let Some(binding) = settings.bindings.get_mut("transcribe_with_post_process") {
-                    if binding.post_process_prompt_id.is_none() {
-                        let prompt_id = settings
-                            .post_process_selected_prompt_id
-                            .clone()
-                            .unwrap_or_else(|| {
-                                crate::post_process::BUILTIN_PROMPT_CORRECT.to_string()
-                            });
-                        debug!(
-                            "Migrating transcribe_with_post_process prompt_id to '{}'",
-                            prompt_id
-                        );
-                        binding.post_process_prompt_id = Some(prompt_id);
-                        updated = true;
-                    }
-                }
-
-                if updated {
-                    debug!("Settings updated with new bindings");
-                    store.set("settings", serde_json::to_value(&settings).unwrap());
-                }
-
-                settings
-            }
-            Err(e) => {
-                warn!("Failed to parse settings: {}", e);
-                // Fall back to default settings if parsing fails
-                let default_settings = get_default_settings();
-                store.set("settings", serde_json::to_value(&default_settings).unwrap());
-                default_settings
-            }
-        }
-    } else {
-        let default_settings = get_default_settings();
-        store.set("settings", serde_json::to_value(&default_settings).unwrap());
-        default_settings
-    };
-
-    let stt_changed = ensure_stt_defaults(&mut settings);
-    let pp_changed = ensure_post_process_defaults(&mut settings);
-    if stt_changed || pp_changed {
-        store.set("settings", serde_json::to_value(&settings).unwrap());
-    }
-
-    settings
+    read_or_create_app_settings(app, true)
 }
 
 pub fn reload_from_disk(app: &AppHandle) -> Result<AppSettings, String> {
@@ -992,31 +1408,11 @@ pub fn reload_from_disk(app: &AppHandle) -> Result<AppSettings, String> {
         .reload()
         .map_err(|e| format!("Failed to reload settings from disk: {}", e))?;
 
-    // Validate that the reloaded JSON can be parsed before applying migrations
-    if let Some(settings_value) = store.get("settings") {
-        serde_json::from_value::<AppSettings>(settings_value)
-            .map_err(|e| format!("Invalid settings in configuration file: {}", e))?;
-    }
-
     Ok(load_or_create_app_settings(app))
 }
 
 pub fn get_settings(app: &AppHandle) -> AppSettings {
-    let store = app
-        .store(SETTINGS_STORE_PATH)
-        .expect("Failed to initialize store");
-
-    if let Some(settings_value) = store.get("settings") {
-        serde_json::from_value::<AppSettings>(settings_value).unwrap_or_else(|_| {
-            let default_settings = get_default_settings();
-            store.set("settings", serde_json::to_value(&default_settings).unwrap());
-            default_settings
-        })
-    } else {
-        let default_settings = get_default_settings();
-        store.set("settings", serde_json::to_value(&default_settings).unwrap());
-        default_settings
-    }
+    read_or_create_app_settings(app, false)
 }
 
 pub fn write_settings(app: &AppHandle, settings: AppSettings) {
@@ -1024,7 +1420,7 @@ pub fn write_settings(app: &AppHandle, settings: AppSettings) {
         .store(SETTINGS_STORE_PATH)
         .expect("Failed to initialize store");
 
-    store.set("settings", serde_json::to_value(&settings).unwrap());
+    store.set("settings", persisted_settings_value(&settings));
 }
 
 pub fn get_bindings(app: &AppHandle) -> HashMap<String, ShortcutBinding> {
@@ -1051,11 +1447,300 @@ pub fn get_recording_retention_period(app: &AppHandle) -> RecordingRetentionPeri
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn default_settings_disable_auto_submit() {
         let settings = get_default_settings();
         assert!(!settings.auto_submit);
         assert_eq!(settings.auto_submit_key, AutoSubmitKey::Enter);
+    }
+
+    #[test]
+    fn legacy_push_to_talk_settings_still_deserialize_into_activation_mode() {
+        let hold_settings = json!({
+            "push_to_talk": true
+        });
+        let toggle_settings = json!({
+            "push_to_talk": false
+        });
+
+        let hold = serde_json::from_value::<AppSettings>(hold_settings).expect("hold settings");
+        let toggle =
+            serde_json::from_value::<AppSettings>(toggle_settings).expect("toggle settings");
+
+        assert_eq!(hold.activation_mode, ActivationMode::Hold);
+        assert_eq!(toggle.activation_mode, ActivationMode::Toggle);
+    }
+
+    #[test]
+    fn recover_settings_preserves_user_data_when_provider_catalog_is_invalid() {
+        let invalid_settings = json!({
+            "bindings": {
+                "transcribe": {
+                    "id": "transcribe",
+                    "name": "Transcribe",
+                    "description": "Converts your speech into text.",
+                    "default_binding": "fn",
+                    "current_binding": "fn",
+                    "post_process_prompt_id": "default_restructure"
+                }
+            },
+            "stt_provider_id": "deepgram",
+            "stt_api_keys": {
+                "deepgram": "dg-key"
+            },
+            "post_process_provider_id": "groq",
+            "post_process_api_keys": {
+                "groq": "groq-key"
+            },
+            "post_process_providers": [
+                {
+                    "id": "custom",
+                    "label": "Custom",
+                    "base_url": "http://localhost:8080/v1",
+                    "allow_base_url_edit": true,
+                    "models_endpoint": "/models",
+                    "supports_structured_output": false
+                }
+            ],
+            "dictionary_terms": ["handless"],
+            "stt_providers": [
+                {
+                    "id": "future",
+                    "label": "Future STT",
+                    "provider_type": "satellite",
+                    "base_url": "https://example.com",
+                    "default_model": "future-1"
+                }
+            ]
+        });
+
+        assert!(serde_json::from_value::<AppSettings>(invalid_settings.clone()).is_err());
+
+        let recovered = recover_settings_from_value(invalid_settings);
+
+        assert_eq!(
+            recovered.stt_api_keys.get("deepgram").map(String::as_str),
+            Some("dg-key")
+        );
+        assert_eq!(
+            recovered
+                .post_process_api_keys
+                .get("groq")
+                .map(String::as_str),
+            Some("groq-key")
+        );
+        assert_eq!(recovered.stt_provider_id, "deepgram");
+        assert_eq!(recovered.post_process_provider_id, "groq");
+        assert_eq!(recovered.dictionary_terms, vec!["handless"]);
+        assert!(recovered
+            .stt_providers
+            .iter()
+            .any(|provider| provider.id == "deepgram"));
+        assert!(recovered
+            .stt_providers
+            .iter()
+            .all(|provider| provider.id != "future"));
+        assert_eq!(
+            recovered
+                .post_process_provider("custom")
+                .map(|provider| provider.base_url.as_str()),
+            Some("http://localhost:8080/v1")
+        );
+    }
+
+    #[test]
+    fn persisted_settings_omit_provider_catalogs_and_keep_custom_base_url() {
+        let mut settings = get_default_settings();
+        settings
+            .post_process_provider_mut("custom")
+            .expect("custom provider should exist")
+            .base_url = "http://localhost:8080/v1".to_string();
+
+        let serialized = persisted_settings_value(&settings);
+        let settings = serialized.as_object().unwrap();
+
+        assert!(!settings.contains_key("stt_providers"));
+        assert!(!settings.contains_key("post_process_providers"));
+        assert_eq!(
+            settings
+                .get("post_process_custom_base_url")
+                .and_then(|value| value.as_str()),
+            Some("http://localhost:8080/v1")
+        );
+    }
+
+    #[test]
+    fn slim_persisted_settings_restore_custom_base_url_after_deserialize() {
+        let settings_value = json!({
+            "post_process_provider_id": "custom",
+            "post_process_models": {
+                "custom": "llama3"
+            },
+            "post_process_api_keys": {
+                "custom": ""
+            },
+            "post_process_custom_base_url": "http://localhost:8080/v1"
+        });
+
+        let mut settings =
+            serde_json::from_value::<AppSettings>(settings_value.clone()).expect("settings parse");
+
+        let object = settings_value
+            .as_object()
+            .expect("settings should be an object");
+        let changed = apply_custom_post_process_base_url(
+            &mut settings,
+            configured_custom_post_process_base_url(object),
+        );
+
+        assert!(changed);
+        assert_eq!(
+            settings
+                .post_process_provider("custom")
+                .map(|provider| provider.base_url.as_str()),
+            Some("http://localhost:8080/v1")
+        );
+    }
+
+    #[test]
+    fn persisted_settings_keep_only_custom_prompts_and_binding_overrides() {
+        let mut settings = get_default_settings();
+        let default_transcribe_binding = settings
+            .bindings
+            .get("transcribe")
+            .expect("transcribe binding should exist")
+            .current_binding
+            .clone();
+        settings
+            .bindings
+            .get_mut("transcribe")
+            .unwrap()
+            .current_binding = if default_transcribe_binding == "ctrl+space" {
+            "alt+space".to_string()
+        } else {
+            "ctrl+space".to_string()
+        };
+        settings
+            .bindings
+            .get_mut("transcribe_with_post_process")
+            .unwrap()
+            .post_process_prompt_id = Some("default_restructure".to_string());
+        settings.bindings.insert(
+            "transcribe_custom_1".to_string(),
+            ShortcutBinding {
+                id: "transcribe_custom_1".to_string(),
+                name: "Custom Transcription".to_string(),
+                description: "Custom transcription shortcut.".to_string(),
+                default_binding: "ctrl+alt+space".to_string(),
+                current_binding: "ctrl+alt+space".to_string(),
+                post_process_prompt_id: Some("prompt_1".to_string()),
+            },
+        );
+        settings.post_process_prompts.push(LLMPrompt {
+            id: "prompt_1".to_string(),
+            name: "Custom".to_string(),
+            prompt: "Rewrite this.".to_string(),
+        });
+
+        let serialized = persisted_settings_value(&settings);
+        let settings = serialized.as_object().unwrap();
+        let bindings = settings
+            .get("bindings")
+            .and_then(JsonValue::as_object)
+            .expect("bindings should be serialized");
+        let prompts = settings
+            .get("post_process_prompts")
+            .and_then(JsonValue::as_array)
+            .expect("prompts should be serialized");
+
+        assert_eq!(bindings.len(), 3);
+        assert_eq!(
+            bindings
+                .get("transcribe")
+                .and_then(JsonValue::as_object)
+                .and_then(|binding| binding.get("name")),
+            None
+        );
+        assert_eq!(
+            bindings
+                .get("transcribe_with_post_process")
+                .and_then(JsonValue::as_object)
+                .and_then(|binding| binding.get("default_binding")),
+            None
+        );
+        assert_eq!(
+            bindings
+                .get("transcribe_custom_1")
+                .and_then(JsonValue::as_object)
+                .and_then(|binding| binding.get("name"))
+                .and_then(JsonValue::as_str),
+            Some("Custom Transcription")
+        );
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(
+            prompts[0]
+                .as_object()
+                .and_then(|prompt| prompt.get("id"))
+                .and_then(JsonValue::as_str),
+            Some("prompt_1")
+        );
+    }
+
+    #[test]
+    fn normalize_settings_definitions_rebuilds_builtin_bindings_and_prompts() {
+        let mut settings = get_default_settings();
+        settings.bindings = HashMap::from([
+            (
+                "transcribe".to_string(),
+                ShortcutBinding {
+                    id: "transcribe".to_string(),
+                    name: String::new(),
+                    description: String::new(),
+                    default_binding: String::new(),
+                    current_binding: "ctrl+space".to_string(),
+                    post_process_prompt_id: None,
+                },
+            ),
+            (
+                "transcribe_custom_1".to_string(),
+                ShortcutBinding {
+                    id: "transcribe_custom_1".to_string(),
+                    name: "Custom Transcription".to_string(),
+                    description: "Custom transcription shortcut.".to_string(),
+                    default_binding: "ctrl+alt+space".to_string(),
+                    current_binding: "ctrl+alt+space".to_string(),
+                    post_process_prompt_id: Some("prompt_1".to_string()),
+                },
+            ),
+        ]);
+        settings.post_process_prompts = vec![LLMPrompt {
+            id: "prompt_1".to_string(),
+            name: "Custom".to_string(),
+            prompt: "Rewrite this.".to_string(),
+        }];
+
+        assert!(normalize_settings_definitions(&mut settings));
+        assert_eq!(
+            settings
+                .bindings
+                .get("transcribe")
+                .map(|binding| binding.name.as_str()),
+            Some("Transcribe")
+        );
+        assert!(settings.bindings.contains_key("cancel"));
+        assert_eq!(
+            settings
+                .post_process_prompts
+                .iter()
+                .filter(|prompt| crate::post_process::is_builtin_prompt(&prompt.id))
+                .count(),
+            crate::post_process::prompts::default_prompts().len()
+        );
+        assert!(settings
+            .post_process_prompts
+            .iter()
+            .any(|prompt| prompt.id == "prompt_1"));
     }
 }

--- a/src-tauri/tests/cloud_stt.rs
+++ b/src-tauri/tests/cloud_stt.rs
@@ -88,7 +88,6 @@ macro_rules! require_audio {
     }};
 }
 
-
 /// Get an API key from the environment, or skip the test.
 macro_rules! require_key {
     ($var:expr) => {{
@@ -840,10 +839,9 @@ mod doubao {
             &["Handless".to_string(), "Tauri".to_string()],
             "",
         );
-        let result =
-            cloud_stt::transcribe("doubao", &key, BASE_URL, MODEL, audio, opts.as_ref())
-                .await
-                .unwrap();
+        let result = cloud_stt::transcribe("doubao", &key, BASE_URL, MODEL, audio, opts.as_ref())
+            .await
+            .unwrap();
         assert_transcript_contains(&result, "test");
     }
 


### PR DESCRIPTION
## Summary
- normalize persisted settings serialization and recovery for provider catalogs and imports
- preserve legacy `push_to_talk` and deprecated builtin prompt migrations during upgrade
- add repository AGENTS guidance and bundled skill documentation

## Test plan
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml --lib -- --nocapture