### PR TITLE
fix: refine realtime overlay bubble

### DIFF
--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -175,15 +175,10 @@
     rgb(8, 6, 4) 100%
   );
   border: 1px solid rgba(var(--color-accent-rgb), 0.07);
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 8px 12px;
   width: 280px;
-  /* Use box-shadow instead of filter: drop-shadow to avoid extending the
-     hit-test area in WKWebView (filter regions can capture pointer events). */
-  box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.5),
-    0 0 0.5px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(var(--color-accent-rgb), 0.04);
+  box-shadow: inset 0 1px 0 rgba(var(--color-accent-rgb), 0.04);
   animation: bubble-enter 250ms cubic-bezier(0.16, 1, 0.3, 1);
   box-sizing: border-box;
   pointer-events: none;

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -28,7 +28,7 @@ const BUTTON_AREA_WIDTH = 20; // px per side for cancel/confirm buttons
 const BUBBLE_CSS_WIDTH = 280; // must match .streaming-text-bubble { width }
 const BUBBLE_CHROME = 18; // 8+8 padding + 1+1 border on .streaming-text-bubble
 const BUBBLE_GAP = 6; // must match .overlay-wrapper { gap }
-const BUBBLE_MARGIN = 10; // window margin around bubble for shadows
+const BUBBLE_MARGIN = 2; // small safety margin around bubble during animation
 
 // Apple-style waveform: thick rounded bars that stretch vertically
 const BAR_WIDTH = 2.5;


### PR DESCRIPTION
## Summary
- remove the outer shadow from the realtime transcription bubble so it does not show a gray halo on light backgrounds
- reduce the extra bubble margin now that the shadow is gone
- slightly increase the realtime bubble corner radius to smooth the shape

## Test plan
- cargo check
- bun x prettier --check src/overlay/RecordingOverlay.css src/overlay/RecordingOverlay.tsx
