### PR TITLE
Improve overlay recording and settings navigation

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1345,7 +1345,7 @@ pub fn get_default_settings() -> AppSettings {
         post_process_models: default_post_process_models(),
         post_process_prompts: default_post_process_prompts(),
         post_process_selected_prompt_id: default_post_process_selected_prompt_id(),
-        mute_while_recording: false,
+        mute_while_recording: true,
         append_trailing_space: false,
         app_language: default_app_language(),
         keyboard_implementation: KeyboardImplementation::default(),

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import { motion, LayoutGroup } from "motion/react";
 import { DragRegion } from "./ui/DragRegion";
 import {
   House,
+  GearSix,
   Command,
   Cube,
   Book,
@@ -14,6 +15,7 @@ import {
 import { useSettings } from "../hooks/useSettings";
 import {
   GeneralSettings,
+  AdvancedSettings,
   ShortcutsSettings,
   HistorySettings,
   DebugSettings,
@@ -75,6 +77,12 @@ export const SECTIONS_CONFIG = {
     labelKey: "sidebar.history",
     icon: ClockCounterClockwise,
     component: HistorySettings,
+    enabled: () => true,
+  },
+  advanced: {
+    labelKey: "sidebar.advanced",
+    icon: GearSix,
+    component: AdvancedSettings,
     enabled: () => true,
   },
   debug: {

--- a/src/components/settings/MuteWhileRecording.tsx
+++ b/src/components/settings/MuteWhileRecording.tsx
@@ -13,7 +13,7 @@ export const MuteWhileRecording: React.FC<MuteWhileRecordingToggleProps> =
     const { t } = useTranslation();
     const { getSetting, updateSetting, isUpdating } = useSettings();
 
-    const muteEnabled = getSetting("mute_while_recording") ?? false;
+    const muteEnabled = getSetting("mute_while_recording") ?? true;
 
     return (
       <ToggleSwitch

--- a/src/components/settings/advanced/AdvancedSettings.tsx
+++ b/src/components/settings/advanced/AdvancedSettings.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useAppVersion } from "@/hooks/useAppVersion";
+import { AutostartToggle } from "../AutostartToggle";
+import { StartHidden } from "../StartHidden";
+import { ShowTrayIcon } from "../ShowTrayIcon";
+import { ModelUnloadTimeoutSetting } from "../ModelUnloadTimeout";
+import { ClipboardHandlingSetting } from "../ClipboardHandling";
+import { AppendTrailingSpace } from "../AppendTrailingSpace";
+import { TypingToolSetting } from "../TypingTool";
+import { MuteWhileRecording } from "../MuteWhileRecording";
+import { ThemeSelector } from "../ThemeSelector";
+import { PasteMethodSetting } from "../PasteMethod";
+import { AutoSubmit } from "../AutoSubmit";
+import { AppLanguageSelector } from "../AppLanguageSelector";
+import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationSelector";
+import { LogDirectory } from "../debug";
+import { AppDataDirectory } from "../AppDataDirectory";
+import { SettingsGroup } from "../../ui/SettingsGroup";
+import { SettingContainer } from "../../ui/SettingContainer";
+import { Button } from "../../ui/Button";
+import { ExportImportSettings } from "./ExportImportSettings";
+import { ConfigFileSettings } from "./ConfigFileSettings";
+
+export const AdvancedSettings: React.FC = () => {
+  const { t } = useTranslation();
+  const version = useAppVersion();
+
+  return (
+    <div className="max-w-3xl w-full space-y-8">
+      <h1 className="sr-only">{t("sidebar.advanced")}</h1>
+
+      <SettingsGroup title={t("settings.advanced.groups.app")}>
+        <AppLanguageSelector descriptionMode="tooltip" grouped={true} />
+        <ThemeSelector descriptionMode="tooltip" grouped={true} />
+        <StartHidden descriptionMode="tooltip" grouped={true} />
+        <AutostartToggle descriptionMode="tooltip" grouped={true} />
+        <ShowTrayIcon descriptionMode="tooltip" grouped={true} />
+        <ModelUnloadTimeoutSetting descriptionMode="tooltip" grouped={true} />
+        <MuteWhileRecording descriptionMode="tooltip" grouped={true} />
+      </SettingsGroup>
+
+      <SettingsGroup title={t("settings.advanced.groups.output")}>
+        <PasteMethodSetting descriptionMode="tooltip" grouped={true} />
+        <AutoSubmit descriptionMode="tooltip" grouped={true} />
+        <ClipboardHandlingSetting descriptionMode="tooltip" grouped={true} />
+        <AppendTrailingSpace descriptionMode="tooltip" grouped={true} />
+        <TypingToolSetting descriptionMode="tooltip" grouped={true} />
+      </SettingsGroup>
+
+      <SettingsGroup title={t("settings.advanced.groups.configuration")}>
+        <KeyboardImplementationSelector
+          descriptionMode="tooltip"
+          grouped={true}
+        />
+        <ConfigFileSettings />
+      </SettingsGroup>
+
+      <SettingsGroup title={t("settings.advanced.groups.data")}>
+        <ExportImportSettings />
+        <AppDataDirectory descriptionMode="tooltip" grouped={true} />
+        <LogDirectory grouped={true} />
+      </SettingsGroup>
+
+      <SettingsGroup title={t("settings.about.title")}>
+        <SettingContainer
+          title={t("settings.about.version.title")}
+          description={t("settings.about.version.description")}
+          grouped={true}
+        >
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          <span className="text-sm font-mono">v{version}</span>
+        </SettingContainer>
+        <SettingContainer
+          title={t("settings.about.sourceCode.title")}
+          description={t("settings.about.sourceCode.description")}
+          grouped={true}
+        >
+          <Button
+            variant="secondary"
+            size="default"
+            onClick={() => openUrl("https://github.com/ElwinLiu/handless")}
+          >
+            {t("settings.about.sourceCode.button")}
+          </Button>
+        </SettingContainer>
+        <SettingContainer
+          title={t("settings.about.acknowledgments.handy.title")}
+          description={t("settings.about.acknowledgments.handy.description")}
+          grouped={true}
+        >
+          <span className="text-sm text-muted">
+            {t("settings.about.acknowledgments.handy.details")}
+          </span>
+        </SettingContainer>
+      </SettingsGroup>
+    </div>
+  );
+};

--- a/src/components/settings/general/GeneralSettings.tsx
+++ b/src/components/settings/general/GeneralSettings.tsx
@@ -1,35 +1,13 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { openUrl } from "@tauri-apps/plugin-opener";
-import { useAppVersion } from "@/hooks/useAppVersion";
 import { MicrophoneSelector } from "../MicrophoneSelector";
 import { SettingsGroup } from "../../ui/SettingsGroup";
-import { SettingContainer } from "../../ui/SettingContainer";
-import { Button } from "../../ui/Button";
 import { VolumeSlider } from "../VolumeSlider";
 import { OutputDeviceSelector } from "../OutputDeviceSelector";
-import { MuteWhileRecording } from "../MuteWhileRecording";
 import { ShowOverlay } from "../ShowOverlay";
-import { ModelUnloadTimeoutSetting } from "../ModelUnloadTimeout";
-import { StartHidden } from "../StartHidden";
-import { AutostartToggle } from "../AutostartToggle";
-import { ShowTrayIcon } from "../ShowTrayIcon";
-import { ThemeSelector } from "../ThemeSelector";
-import { PasteMethodSetting } from "../PasteMethod";
-import { TypingToolSetting } from "../TypingTool";
-import { ClipboardHandlingSetting } from "../ClipboardHandling";
-import { AutoSubmit } from "../AutoSubmit";
-import { KeyboardImplementationSelector } from "../debug/KeyboardImplementationSelector";
-import { ExportImportSettings } from "../advanced/ExportImportSettings";
-import { ConfigFileSettings } from "../advanced/ConfigFileSettings";
-import { AppLanguageSelector } from "../AppLanguageSelector";
-import { AppDataDirectory } from "../AppDataDirectory";
-import { AppendTrailingSpace } from "../AppendTrailingSpace";
-import { LogDirectory } from "../debug";
 
 export const GeneralSettings: React.FC = () => {
   const { t } = useTranslation();
-  const version = useAppVersion();
 
   return (
     <div className="max-w-3xl w-full space-y-8">
@@ -37,71 +15,12 @@ export const GeneralSettings: React.FC = () => {
 
       <SettingsGroup title={t("settings.sound.title")}>
         <MicrophoneSelector descriptionMode="tooltip" grouped={true} />
-        <MuteWhileRecording descriptionMode="tooltip" grouped={true} />
         <VolumeSlider />
         <OutputDeviceSelector descriptionMode="tooltip" grouped={true} />
       </SettingsGroup>
 
       <SettingsGroup title={t("settings.advanced.groups.app")}>
-        <AppLanguageSelector descriptionMode="tooltip" grouped={true} />
-        <ThemeSelector descriptionMode="tooltip" grouped={true} />
-        <StartHidden descriptionMode="tooltip" grouped={true} />
-        <AutostartToggle descriptionMode="tooltip" grouped={true} />
-        <ShowTrayIcon descriptionMode="tooltip" grouped={true} />
         <ShowOverlay descriptionMode="tooltip" grouped={true} />
-        <ModelUnloadTimeoutSetting descriptionMode="tooltip" grouped={true} />
-        <KeyboardImplementationSelector
-          descriptionMode="tooltip"
-          grouped={true}
-        />
-      </SettingsGroup>
-
-      <SettingsGroup title={t("settings.advanced.groups.output")}>
-        <PasteMethodSetting descriptionMode="tooltip" grouped={true} />
-        <TypingToolSetting descriptionMode="tooltip" grouped={true} />
-        <ClipboardHandlingSetting descriptionMode="tooltip" grouped={true} />
-        <AutoSubmit descriptionMode="tooltip" grouped={true} />
-        <AppendTrailingSpace descriptionMode="tooltip" grouped={true} />
-      </SettingsGroup>
-
-      <SettingsGroup title={t("settings.advanced.groups.data")}>
-        <ExportImportSettings />
-        <AppDataDirectory descriptionMode="tooltip" grouped={true} />
-        <LogDirectory grouped={true} />
-        <ConfigFileSettings />
-      </SettingsGroup>
-
-      <SettingsGroup title={t("settings.about.title")}>
-        <SettingContainer
-          title={t("settings.about.version.title")}
-          description={t("settings.about.version.description")}
-          grouped={true}
-        >
-          {/* eslint-disable-next-line i18next/no-literal-string */}
-          <span className="text-sm font-mono">v{version}</span>
-        </SettingContainer>
-        <SettingContainer
-          title={t("settings.about.sourceCode.title")}
-          description={t("settings.about.sourceCode.description")}
-          grouped={true}
-        >
-          <Button
-            variant="secondary"
-            size="default"
-            onClick={() => openUrl("https://github.com/ElwinLiu/handless")}
-          >
-            {t("settings.about.sourceCode.button")}
-          </Button>
-        </SettingContainer>
-        <SettingContainer
-          title={t("settings.about.acknowledgments.handy.title")}
-          description={t("settings.about.acknowledgments.handy.description")}
-          grouped={true}
-        >
-          <span className="text-sm text-muted">
-            {t("settings.about.acknowledgments.handy.details")}
-          </span>
-        </SettingContainer>
       </SettingsGroup>
     </div>
   );

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,5 +1,6 @@
 // Settings section components
 export { GeneralSettings } from "./general/GeneralSettings";
+export { AdvancedSettings } from "./advanced/AdvancedSettings";
 export { ShortcutsSettings } from "./shortcuts/ShortcutsSettings";
 export { DebugSettings } from "./debug/DebugSettings";
 export { HistorySettings } from "./history/HistorySettings";

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "عام",
+    "advanced": "Advanced",
     "shortcuts": "اختصارات",
     "dictionary": "القاموس",
     "postProcessing": "معالجة لاحقة",

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Obecné",
+    "advanced": "Advanced",
     "shortcuts": "Zkratky",
     "models": "Modely",
     "dictionary": "Slovník",

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Allgemein",
+    "advanced": "Advanced",
     "shortcuts": "Tastenkürzel",
     "models": "Modelle",
     "dictionary": "Wörterbuch",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "General",
+    "advanced": "Advanced",
     "shortcuts": "Shortcuts",
     "models": "Models",
     "dictionary": "Dictionary",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "General",
+    "advanced": "Advanced",
     "shortcuts": "Atajos",
     "models": "Modelos",
     "dictionary": "Diccionario",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Général",
+    "advanced": "Advanced",
     "shortcuts": "Raccourcis",
     "models": "Modèles",
     "dictionary": "Dictionnaire",

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Generale",
+    "advanced": "Advanced",
     "shortcuts": "Scorciatoie",
     "models": "Modelli",
     "dictionary": "Dizionario",

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "一般",
+    "advanced": "Advanced",
     "shortcuts": "ショートカット",
     "models": "モデル",
     "dictionary": "辞書",

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "일반",
+    "advanced": "Advanced",
     "shortcuts": "단축키",
     "models": "모델",
     "dictionary": "사전",

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Ogólne",
+    "advanced": "Advanced",
     "shortcuts": "Skróty",
     "models": "Modele",
     "dictionary": "Słownik",

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Geral",
+    "advanced": "Advanced",
     "shortcuts": "Atalhos",
     "models": "Modelos",
     "dictionary": "Dicionário",

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Общие",
+    "advanced": "Advanced",
     "shortcuts": "Горячие клавиши",
     "models": "Модели",
     "dictionary": "Словарь",

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Genel",
+    "advanced": "Advanced",
     "shortcuts": "Kısayollar",
     "models": "Modeller",
     "dictionary": "Sözlük",

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Загальні",
+    "advanced": "Advanced",
     "shortcuts": "Гарячі клавіші",
     "models": "Моделі",
     "dictionary": "Dictionary",

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "Chung",
+    "advanced": "Advanced",
     "shortcuts": "Phím tắt",
     "models": "Mô hình",
     "dictionary": "Từ điển",

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "一般",
+    "advanced": "Advanced",
     "shortcuts": "快捷鍵",
     "models": "模型",
     "dictionary": "字典",

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -10,6 +10,7 @@
   },
   "sidebar": {
     "general": "通用",
+    "advanced": "Advanced",
     "shortcuts": "快捷键",
     "models": "模型",
     "dictionary": "词典",

--- a/src/overlay/RecordingOverlay.css
+++ b/src/overlay/RecordingOverlay.css
@@ -79,6 +79,15 @@
     clip-path 280ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+/* Inline streaming text needs its final width immediately, otherwise the
+   first scrollHeight measurement is taken while the pill is still narrow. */
+.recording-overlay.has-inline-text,
+.recording-overlay.fade-in.has-inline-text {
+  transition:
+    opacity 180ms ease-out,
+    transform 280ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
 /* Fade-in any new content block (exclude absolutely-positioned buttons) */
 .recording-overlay > *:not(.overlay-btn):not(.postprocess-dismiss) {
   animation: content-enter 200ms ease-out;

--- a/src/overlay/RecordingOverlay.tsx
+++ b/src/overlay/RecordingOverlay.tsx
@@ -130,18 +130,18 @@ const RecordingOverlay: React.FC = () => {
   const buttonsExtra = showButtons ? BUTTON_AREA_WIDTH * 2 : 0;
   // Toggle mode: text floats above waveform bars instead of replacing them
   const showTextAboveBars = hasStreamingText && activationMode === "toggle";
+  const showInlineStreamingText = hasStreamingText && !showTextAboveBars;
 
   // Compute overlay dimensions — pill never changes shape in toggle mode
   const overlayWidth = (() => {
     if (!isVisible) return 33;
-    if (hasStreamingText && !showTextAboveBars)
-      return STREAMING_WIDTH + buttonsExtra;
+    if (showInlineStreamingText) return STREAMING_WIDTH + buttonsExtra;
     return 70 + buttonsExtra;
   })();
 
   const overlayHeight = (() => {
     if (!isVisible) return 33;
-    if (hasStreamingText && !showTextAboveBars && contentHeight > 0) {
+    if (showInlineStreamingText && contentHeight > 0) {
       const maxTextHeight = STREAMING_LINE_HEIGHT * MAX_LINES;
       const clampedHeight = Math.min(contentHeight, maxTextHeight);
       return Math.max(33, clampedHeight + OVERLAY_PADDING);
@@ -149,8 +149,8 @@ const RecordingOverlay: React.FC = () => {
     return 33;
   })();
 
-  const overlayRadius = hasStreamingText && !showTextAboveBars ? 14 : 999;
-  const buttonRadius = hasStreamingText && !showTextAboveBars ? 8 : 13;
+  const overlayRadius = showInlineStreamingText ? 14 : 999;
+  const buttonRadius = showInlineStreamingText ? 8 : 13;
 
   // Track words (runs before paint to avoid flicker)
   useLayoutEffect(() => {
@@ -487,7 +487,7 @@ const RecordingOverlay: React.FC = () => {
           borderRadius: overlayRadius,
           clipPath: `inset(0 round ${overlayRadius}px)`,
         }}
-        className={`recording-overlay ${isVisible ? "fade-in" : ""} ${showButtons ? "has-buttons" : ""}`}
+        className={`recording-overlay ${isVisible ? "fade-in" : ""} ${showButtons ? "has-buttons" : ""} ${showInlineStreamingText ? "has-inline-text" : ""}`}
       >
         {state === "recording" && (
           <>
@@ -499,7 +499,7 @@ const RecordingOverlay: React.FC = () => {
             >
               <X size={12} weight="bold" aria-hidden="true" />
             </button>
-            {hasStreamingText && !showTextAboveBars && (
+            {showInlineStreamingText && (
               <div ref={streamingTextRef} className="streaming-text">
                 {streamingWords}
               </div>


### PR DESCRIPTION
## Summary
- stabilize the hold-to-record overlay streaming layout
- move advanced and about controls into a dedicated Advanced settings section
- default mute-while-recording to enabled and add the new sidebar label across locales

## Test plan
- bun run lint
- bun run check:translations
- bun run build
