### PR TITLE
fix(models): clarify Doubao credential labels

### DIFF
--- a/src-tauri/src/cloud_stt/doubao.rs
+++ b/src-tauri/src/cloud_stt/doubao.rs
@@ -50,7 +50,7 @@ pub(crate) enum DoubaoEvent {
 // ─── Credential extraction ──────────────────────────────────────────
 
 /// Extract the three Doubao credentials:
-/// - `access_key` from the `api_key` parameter (the main API Key field)
+/// - `access_token` from the main credential field
 /// - `app_key` and `resource_id` from the cloud options
 pub(crate) fn extract_credentials<'a>(
     api_key: &'a str,
@@ -69,7 +69,8 @@ pub(crate) fn extract_credentials<'a>(
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .unwrap_or(DEFAULT_RESOURCE_ID);
-    Ok((api_key, app_key, resource_id))
+    let access_token = api_key;
+    Ok((access_token, app_key, resource_id))
 }
 
 /// Map app language codes to Doubao API language codes.

--- a/src/components/settings/PostProcessingSettingsApi/ApiKeyField.tsx
+++ b/src/components/settings/PostProcessingSettingsApi/ApiKeyField.tsx
@@ -10,11 +10,20 @@ interface ApiKeyFieldProps {
   onChange?: (value: string) => void;
   disabled: boolean;
   placeholder?: string;
+  ariaLabel?: string;
   className?: string;
 }
 
 export const ApiKeyField: React.FC<ApiKeyFieldProps> = React.memo(
-  ({ value, onBlur, onChange, disabled, placeholder, className = "" }) => {
+  ({
+    value,
+    onBlur,
+    onChange,
+    disabled,
+    placeholder,
+    ariaLabel,
+    className = "",
+  }) => {
     const { t } = useTranslation();
     const [localValue, setLocalValue] = useState(value);
     const [showCopied, setShowCopied] = useState(false);
@@ -53,6 +62,7 @@ export const ApiKeyField: React.FC<ApiKeyFieldProps> = React.memo(
             if (localValue !== value) onBlur(localValue);
           }}
           placeholder={placeholder}
+          aria-label={ariaLabel}
           variant="compact"
           disabled={disabled}
           className={`w-full ${localValue ? "pr-7" : ""}`}

--- a/src/components/settings/models/CloudProviderConfigCard.tsx
+++ b/src/components/settings/models/CloudProviderConfigCard.tsx
@@ -276,6 +276,19 @@ export const CloudProviderConfigCard: React.FC<
   const effectiveStatus =
     !isVerified && status === "active" ? "available" : status;
   const isClickable = isVerified;
+  const isDoubao = provider.id === "doubao";
+  const credentialLabel = isDoubao
+    ? t("settings.models.cloudProviders.doubao.accessToken")
+    : t("settings.models.cloudProviders.apiKey.title");
+  const credentialPlaceholder = isDoubao
+    ? t("settings.models.cloudProviders.doubao.accessTokenPlaceholder")
+    : t("settings.models.cloudProviders.apiKey.placeholder");
+  const verifyFirstLabel = isDoubao
+    ? t("settings.models.cloudProviders.doubao.verifyFirst")
+    : t("settings.models.cloudProviders.verifyFirst");
+  const consoleButtonLabel = isDoubao
+    ? t("settings.models.cloudProviders.doubao.openSpeechConsole")
+    : t("settings.models.cloudProviders.getApiKey");
 
   const [showVerifyHint, setShowVerifyHint] = useState(false);
   const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -328,7 +341,7 @@ export const CloudProviderConfigCard: React.FC<
         )}
         {showVerifyHint && (
           <span className="text-xs text-warning font-medium animate-pulse">
-            {t("settings.models.cloudProviders.verifyFirst")}
+            {verifyFirstLabel}
           </span>
         )}
         <button
@@ -365,9 +378,8 @@ export const CloudProviderConfigCard: React.FC<
                 onBlur={onApiKeyChange}
                 onChange={setLocalApiKey}
                 disabled={false}
-                placeholder={t(
-                  "settings.models.cloudProviders.apiKey.placeholder",
-                )}
+                placeholder={credentialPlaceholder}
+                ariaLabel={credentialLabel}
                 className="min-w-[180px] max-w-[240px]"
               />
               <Input
@@ -433,7 +445,7 @@ export const CloudProviderConfigCard: React.FC<
                     }}
                   >
                     <ArrowSquareOut className="w-3 h-3" />
-                    {t("settings.models.cloudProviders.getApiKey")}
+                    {consoleButtonLabel}
                   </button>
                 )}
             </div>

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -333,7 +333,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/cs/translation.json
+++ b/src/i18n/locales/cs/translation.json
@@ -279,7 +279,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/de/translation.json
+++ b/src/i18n/locales/de/translation.json
@@ -279,7 +279,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -333,7 +333,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -279,7 +279,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -279,7 +279,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/it/translation.json
+++ b/src/i18n/locales/it/translation.json
@@ -279,7 +279,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -279,7 +279,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/ko/translation.json
+++ b/src/i18n/locales/ko/translation.json
@@ -352,7 +352,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/pl/translation.json
+++ b/src/i18n/locales/pl/translation.json
@@ -333,7 +333,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -333,7 +333,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/ru/translation.json
+++ b/src/i18n/locales/ru/translation.json
@@ -279,7 +279,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/tr/translation.json
+++ b/src/i18n/locales/tr/translation.json
@@ -333,7 +333,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/uk/translation.json
+++ b/src/i18n/locales/uk/translation.json
@@ -333,7 +333,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/vi/translation.json
+++ b/src/i18n/locales/vi/translation.json
@@ -333,7 +333,11 @@
           "appKey": "App Key (App ID)",
           "appKeyDescription": "Your Volcengine App ID (from the Speech console)",
           "resourceId": "Resource ID",
-          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)"
+          "resourceIdDescription": "Your Volcengine speech resource ID (from the Speech console)",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "Verify your Access Token first",
+          "openSpeechConsole": "Open speech console"
         }
       },
       "localModels": {

--- a/src/i18n/locales/zh-TW/translation.json
+++ b/src/i18n/locales/zh-TW/translation.json
@@ -333,7 +333,11 @@
           "appKey": "應用金鑰 (App ID)",
           "appKeyDescription": "火山引擎 App ID（從語音控制台取得）",
           "resourceId": "資源 ID",
-          "resourceIdDescription": "火山引擎語音資源 ID（從語音控制台取得）"
+          "resourceIdDescription": "火山引擎語音資源 ID（從語音控制台取得）",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "請先驗證您的 Access Token",
+          "openSpeechConsole": "開啟語音控制台"
         }
       },
       "localModels": {

--- a/src/i18n/locales/zh/translation.json
+++ b/src/i18n/locales/zh/translation.json
@@ -279,7 +279,11 @@
           "appKey": "应用密钥 (App ID)",
           "appKeyDescription": "火山引擎 App ID（从语音控制台获取）",
           "resourceId": "资源 ID",
-          "resourceIdDescription": "火山引擎语音资源 ID（从语音控制台获取）"
+          "resourceIdDescription": "火山引擎语音资源 ID（从语音控制台获取）",
+          "accessToken": "Access Token",
+          "accessTokenPlaceholder": "Access Token",
+          "verifyFirst": "请先验证您的 Access Token",
+          "openSpeechConsole": "打开语音控制台"
         }
       },
       "localModels": {


### PR DESCRIPTION
## Summary
- Rename the Doubao main credential field copy from API key to Access Token.
- Add provider-specific verification and console labels for Doubao.
- Keep all locale files aligned with the new translation keys.

## Test plan
- bun run check:translations
- bun run lint